### PR TITLE
Modals now grow with content but scroll with window

### DIFF
--- a/src/renderer/components/Modal/ModalContent.js
+++ b/src/renderer/components/Modal/ModalContent.js
@@ -5,9 +5,10 @@ import styled from "styled-components";
 
 const ContentWrapper = styled.div`
   position: relative;
-  flex: 0;
+  flex: 1;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 `;
 
 const ContentScrollableContainer = styled.div`

--- a/src/renderer/components/Modal/index.js
+++ b/src/renderer/components/Modal/index.js
@@ -258,6 +258,7 @@ const BODY_WRAPPER_STYLE = {
   flexShrink: 1,
   display: "flex",
   flexDirection: "column",
+  overflow: "auto",
 };
 
 // $FlowFixMe: define a OwnProps


### PR DESCRIPTION
The modals didn't want to  grow and shrink with the window, after a whole day of not understanding why they now do and I don't.

### Type

Bug Fix?
