### PR TITLE
AccountS screen

### DIFF
--- a/src/renderer/actions/portfolio.js
+++ b/src/renderer/actions/portfolio.js
@@ -9,6 +9,7 @@ import type {
   CryptoCurrency,
   PortfolioRange,
   TokenCurrency,
+  AccountLike,
 } from "@ledgerhq/live-common/lib/types";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/lib/account";
 
@@ -28,7 +29,7 @@ export const balanceHistoryWithCountervalueSelector = (
     account,
     range,
   }: {
-    account: Account,
+    account: AccountLike,
     range: PortfolioRange,
   },
 ) => {

--- a/src/renderer/components/AssetDistribution/index.js
+++ b/src/renderer/components/AssetDistribution/index.js
@@ -112,8 +112,8 @@ class AssetDistribution extends PureComponent<Props, State> {
   }
 }
 
-const ConnectedAssedDistribution: React$ComponentType<{}> = connect(mapStateToProps)(
+const ConnectedAssetDistribution: React$ComponentType<{}> = connect(mapStateToProps)(
   AssetDistribution,
 );
 
-export default ConnectedAssedDistribution;
+export default ConnectedAssetDistribution;

--- a/src/renderer/components/ContextMenu/AccountContextMenu.js
+++ b/src/renderer/components/ContextMenu/AccountContextMenu.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from "react";
 import { openModal } from "~/renderer/actions/modals";
-import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types/account";
+import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types/account";
 import { connect } from "react-redux";
 import IconReceive from "~/renderer/icons/Receive";
 import IconSend from "~/renderer/icons/Send";
@@ -12,8 +12,8 @@ import ContextMenuItem from "./ContextMenuItem";
 import { toggleStarAction } from "~/renderer/actions/settings";
 
 type OwnProps = {
-  account: TokenAccount | Account,
-  parentAccount: ?Account,
+  account: AccountLike,
+  parentAccount?: ?Account,
   leftClick?: boolean,
   children: any,
 };

--- a/src/renderer/components/StickyBackToTop.js
+++ b/src/renderer/components/StickyBackToTop.js
@@ -34,7 +34,7 @@ const Container = styled(Box)`
 type Props = {
   scrollUpOnMount?: boolean,
   scrollThreshold: number,
-  getGrowScroll: () => { scrollContainer: ?HTMLDivElement },
+  growScroll: { scrollContainer: ?HTMLDivElement },
 };
 
 type State = {
@@ -51,7 +51,8 @@ class StickyBackToTop extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    const { scrollContainer } = this.props.getGrowScroll();
+    console.log(this.props);
+    const { scrollContainer } = this.props.growScroll;
     if (scrollContainer) {
       const listener = () => {
         if (this._unmounted) return;
@@ -81,7 +82,7 @@ class StickyBackToTop extends PureComponent<Props, State> {
   _unmounted = false;
 
   onClick = () => {
-    const { scrollContainer } = this.props.getGrowScroll();
+    const { scrollContainer } = this.props.growScroll;
     if (scrollContainer) {
       // $FlowFixMe seems to be missing in flow
       scrollContainer.scrollTo({ top: 0, behavior: "smooth" });
@@ -106,7 +107,7 @@ class StickyBackToTop extends PureComponent<Props, State> {
 
 const StickyBackToTopWrapper = (props: { scrollThreshold?: number }) => (
   <GrowScrollContext.Consumer>
-    {getGrowScroll => <StickyBackToTop {...props} getGrowScroll={getGrowScroll} />}
+    {growScroll => <StickyBackToTop {...props} growScroll={growScroll} />}
   </GrowScrollContext.Consumer>
 );
 

--- a/src/renderer/screens/accounts/AccountGridItem/Body.js
+++ b/src/renderer/screens/accounts/AccountGridItem/Body.js
@@ -1,0 +1,75 @@
+// @flow
+
+import React from "react";
+import styled from "styled-components";
+import { useSelector } from "react-redux";
+import { balanceHistoryWithCountervalueSelector } from "~/renderer/actions/portfolio";
+import type { Account, TokenAccount, PortfolioRange } from "@ledgerhq/live-common/lib/types";
+import { getCurrencyColor } from "~/renderer/getCurrencyColor";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account";
+import Box from "~/renderer/components/Box";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import CounterValue from "~/renderer/components/CounterValue";
+import Chart from "~/renderer/components/Chart";
+import useTheme from "~/renderer/hooks/useTheme";
+
+const Placeholder = styled.div`
+  height: 14px;
+`;
+
+type Props = {
+  account: Account | TokenAccount,
+  range: PortfolioRange,
+};
+
+// $FlowFixMe
+const mapValueCounterValue = d => d.countervalue.toNumber();
+const mapValue = d => d.value.toNumber();
+
+const Body = ({ account, range }: Props) => {
+  const { history, countervalueAvailable, countervalueChange } = useSelector(state =>
+    balanceHistoryWithCountervalueSelector(state, { account, range }),
+  );
+  const bgColor = useTheme("theme.colors.palette.background.paper");
+  const currency = getAccountCurrency(account);
+
+  return (
+    <Box flow={4}>
+      <Box flow={2} horizontal>
+        <Box justifyContent="center">
+          <CounterValue
+            currency={currency}
+            value={history[history.length - 1].value}
+            animateTicker={false}
+            alwaysShowSign={false}
+            showCode
+            fontSize={3}
+            placeholder={<Placeholder />}
+            color="palette.text.shade80"
+          />
+        </Box>
+        <Box grow justifyContent="center">
+          {!countervalueChange.percentage ? null : (
+            <FormattedVal
+              isPercent
+              val={countervalueChange.percentage.times(100).integerValue()}
+              alwaysShowSign
+              fontSize={3}
+            />
+          )}
+        </Box>
+      </Box>
+      <Chart
+        data={history}
+        color={getCurrencyColor(currency, bgColor)}
+        mapValue={countervalueAvailable ? mapValueCounterValue : mapValue}
+        height={52}
+        hideAxis
+        isInteractive={false}
+        id={`account-chart-${account.id}`}
+      />
+    </Box>
+  );
+};
+
+export default Body;

--- a/src/renderer/screens/accounts/AccountGridItem/Header.js
+++ b/src/renderer/screens/accounts/AccountGridItem/Header.js
@@ -1,0 +1,96 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
+import {
+  getAccountCurrency,
+  getAccountUnit,
+  getAccountName,
+} from "@ledgerhq/live-common/lib/account";
+import Box from "~/renderer/components/Box";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import Bar from "~/renderer/components/Bar";
+import Text from "~/renderer/components/Text";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import ParentCryptoCurrencyIcon from "~/renderer/components/ParentCryptoCurrencyIcon";
+import Tooltip from "~/renderer/components/Tooltip";
+import AccountSyncStatusIndicator from "../AccountSyncStatusIndicator";
+// TODO Port Stars 🌟
+// import Star from "~/renderer/components/Stars/Star";
+
+class HeadText extends PureComponent<{
+  title: string,
+  name: string,
+}> {
+  render() {
+    const { title, name } = this.props;
+
+    return (
+      <Box style={{ flex: 1, alignItems: "flex-start" }}>
+        <Box style={{ textTransform: "uppercase" }} fontSize={10} color="palette.text.shade80">
+          {title}
+        </Box>
+        <Tooltip content={name} delay={1200}>
+          <Ellipsis>
+            <Text fontSize={13} color="palette.text.shade100">
+              {name}
+            </Text>
+          </Ellipsis>
+        </Tooltip>
+      </Box>
+    );
+  }
+}
+
+class Header extends PureComponent<{
+  account: Account | TokenAccount,
+  parentAccount: ?Account,
+}> {
+  render() {
+    const { account, parentAccount } = this.props;
+    const currency = getAccountCurrency(account);
+    const unit = getAccountUnit(account);
+    const name = getAccountName(account);
+
+    let title;
+    switch (account.type) {
+      case "Account":
+      case "AccountChild":
+        title = currency.name;
+        break;
+      case "TokenAccount":
+        title = "token";
+        break;
+      default:
+        title = "";
+    }
+
+    return (
+      <Box flow={4}>
+        <Box horizontal ff="Inter|SemiBold" flow={3} alignItems="center">
+          <ParentCryptoCurrencyIcon currency={currency} withTooltip />
+          <HeadText name={name} title={title} />
+          <AccountSyncStatusIndicator
+            accountId={(parentAccount && parentAccount.id) || account.id}
+            account={account}
+          />
+          {/* <Star accountId={account.id} /> */}
+        </Box>
+        <Bar size={1} color="palette.divider" />
+        <Box justifyContent="center">
+          <FormattedVal
+            alwaysShowSign={false}
+            animateTicker={false}
+            ellipsis
+            color="palette.text.shade100"
+            unit={unit}
+            showCode
+            val={account.balance}
+          />
+        </Box>
+      </Box>
+    );
+  }
+}
+
+export default Header;

--- a/src/renderer/screens/accounts/AccountGridItem/Placeholder.js
+++ b/src/renderer/screens/accounts/AccountGridItem/Placeholder.js
@@ -1,0 +1,54 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import styled from "styled-components";
+
+import { openModal } from "~/renderer/actions/modals";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+// TODO rework Image component
+// import Image from "~/renderer/components/Image";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const Wrapper: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  p: 4,
+  flex: 1,
+  alignItems: "center",
+}))`
+  border: 1px dashed ${p => p.theme.colors.palette.divider};
+  border-radius: 4px;
+  height: 215px;
+`;
+
+const Placeholder = () => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return (
+    <Box mb={5}>
+      <Wrapper data-e2e="dashboard_AccountPlaceOrder">
+        <Box mt={2}>
+          {/* <Image alt="empty account placeholder" resource="empty-account-tile.svg" themeTyped /> */}
+        </Box>
+        <Box
+          ff="Inter"
+          fontSize={3}
+          color="palette.text.shade60"
+          pb={2}
+          mt={3}
+          textAlign="center"
+          style={{ maxWidth: 150 }}
+        >
+          {t("dashboard.emptyAccountTile.desc")}
+        </Box>
+        <Button primary onClick={() => dispatch(openModal("MODAL_ADD_ACCOUNTS"))}>
+          {t("dashboard.emptyAccountTile.createAccount")}
+        </Button>
+      </Wrapper>
+    </Box>
+  );
+};
+
+export default Placeholder;

--- a/src/renderer/screens/accounts/AccountGridItem/index.js
+++ b/src/renderer/screens/accounts/AccountGridItem/index.js
@@ -1,0 +1,65 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import styled from "styled-components";
+import type { TokenAccount, Account, PortfolioRange } from "@ledgerhq/live-common/lib/types";
+import Box from "~/renderer/components/Box";
+import AccountCardHeader from "./Header";
+import AccountCardBody from "./Body";
+// TODO port context menu
+// import AccountContextMenu from "~/renderer/components/ContextMenu/AccountContextMenu";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const Card: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  bg: "palette.background.paper",
+  p: 3,
+  boxShadow: 0,
+  borderRadius: 1,
+}))`
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background-color ease-in-out 200ms;
+  :hover {
+    border-color: ${p => p.theme.colors.palette.text.shade20};
+  }
+  :active {
+    border-color: ${p => p.theme.colors.palette.text.shade20};
+    background: ${p => p.theme.colors.palette.action.hover};
+  }
+`;
+
+type Props = {
+  hidden?: boolean,
+  account: TokenAccount | Account,
+  parentAccount: ?Account,
+  onClick: (Account | TokenAccount, ?Account) => void,
+  range: PortfolioRange,
+};
+
+class AccountCard extends PureComponent<Props> {
+  onClick = () => {
+    const { account, parentAccount, onClick } = this.props;
+    onClick(account, parentAccount);
+  };
+
+  render() {
+    const { account, parentAccount, range, hidden, ...props } = this.props;
+
+    return (
+      // <AccountContextMenu account={account} parentAccount={parentAccount}>
+      <Card
+        {...props}
+        style={{ display: hidden && "none" }}
+        p={20}
+        onClick={this.onClick}
+        data-e2e="dashboard_AccountCardWrapper"
+      >
+        <AccountCardHeader account={account} parentAccount={parentAccount} />
+        <AccountCardBody account={account} parentAccount={parentAccount} range={range} />
+      </Card>
+      // </AccountContextMenu>
+    );
+  }
+}
+
+export default AccountCard;

--- a/src/renderer/screens/accounts/AccountGridItem/index.js
+++ b/src/renderer/screens/accounts/AccountGridItem/index.js
@@ -6,8 +6,7 @@ import type { TokenAccount, Account, PortfolioRange } from "@ledgerhq/live-commo
 import Box from "~/renderer/components/Box";
 import AccountCardHeader from "./Header";
 import AccountCardBody from "./Body";
-// TODO port context menu
-// import AccountContextMenu from "~/renderer/components/ContextMenu/AccountContextMenu";
+import AccountContextMenu from "~/renderer/components/ContextMenu/AccountContextMenu";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 const Card: ThemedComponent<{}> = styled(Box).attrs(() => ({
@@ -46,18 +45,18 @@ class AccountCard extends PureComponent<Props> {
     const { account, parentAccount, range, hidden, ...props } = this.props;
 
     return (
-      // <AccountContextMenu account={account} parentAccount={parentAccount}>
-      <Card
-        {...props}
-        style={{ display: hidden && "none" }}
-        p={20}
-        onClick={this.onClick}
-        data-e2e="dashboard_AccountCardWrapper"
-      >
-        <AccountCardHeader account={account} parentAccount={parentAccount} />
-        <AccountCardBody account={account} parentAccount={parentAccount} range={range} />
-      </Card>
-      // </AccountContextMenu>
+      <AccountContextMenu account={account} parentAccount={parentAccount}>
+        <Card
+          {...props}
+          style={{ display: hidden && "none" }}
+          p={20}
+          onClick={this.onClick}
+          data-e2e="dashboard_AccountCardWrapper"
+        >
+          <AccountCardHeader account={account} parentAccount={parentAccount} />
+          <AccountCardBody account={account} parentAccount={parentAccount} range={range} />
+        </Card>
+      </AccountContextMenu>
     );
   }
 }

--- a/src/renderer/screens/accounts/AccountList/GridBody.js
+++ b/src/renderer/screens/accounts/AccountList/GridBody.js
@@ -1,0 +1,62 @@
+// @flow
+
+import React from "react";
+import styled from "styled-components";
+import type { Account, PortfolioRange, TokenAccount } from "@ledgerhq/live-common/lib/types";
+
+import Box from "~/renderer/components/Box";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+import AccountCard from "../AccountGridItem";
+import AccountCardPlaceholder from "../AccountGridItem/Placeholder";
+
+type Props = {
+  visibleAccounts: (Account | TokenAccount)[],
+  hiddenAccounts: (Account | TokenAccount)[],
+  onAccountClick: (Account | TokenAccount) => void,
+  lookupParentAccount: (id: string) => ?Account,
+  range: PortfolioRange,
+  showNewAccount: boolean,
+};
+
+const GridBox: ThemedComponent<{}> = styled(Box)`
+  margin-top: 18px;
+  display: grid;
+  grid-gap: 18px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+`;
+
+const GridBody = ({
+  visibleAccounts,
+  hiddenAccounts,
+  range,
+  showNewAccount,
+  onAccountClick,
+  lookupParentAccount,
+  ...rest
+}: Props) => (
+  <GridBox {...rest}>
+    {visibleAccounts.map(account => (
+      <AccountCard
+        key={account.id}
+        account={account}
+        parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
+        range={range}
+        onClick={onAccountClick}
+      />
+    ))}
+    {showNewAccount ? <AccountCardPlaceholder key="placeholder" /> : null}
+    {hiddenAccounts.map(account => (
+      <AccountCard
+        hidden
+        key={account.id}
+        account={account}
+        parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
+        range={range}
+        onClick={onAccountClick}
+      />
+    ))}
+  </GridBox>
+);
+
+export default GridBody;

--- a/src/renderer/screens/accounts/AccountList/Header.js
+++ b/src/renderer/screens/accounts/AccountList/Header.js
@@ -1,0 +1,88 @@
+// @flow
+
+import React, { useState } from "react";
+import styled from "styled-components";
+import type { PortfolioRange } from "@ledgerhq/live-common/lib/types/portfolio";
+
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import GridIcon from "~/renderer/icons/Grid";
+import ListIcon from "~/renderer/icons/List";
+import SearchIcon from "~/renderer/icons/Search";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+import { GenericBox } from "../index";
+import AccountsOrder from "./Order";
+import AccountsRange from "./Range";
+
+type Props = {
+  onModeChange: (*) => void,
+  onTextChange: (evt: SyntheticInputEvent<HTMLInputElement>) => void,
+  onRangeChange: PortfolioRange => void,
+  mode: string,
+  search?: string,
+  range?: PortfolioRange,
+};
+
+const ToggleButton: ThemedComponent<{ active?: boolean }> = styled(Button)`
+  height: 30px;
+  width: 30px;
+  padding: 7px;
+  background: ${p =>
+    p.active ? p.theme.colors.pillActiveBackground : p.theme.colors.palette.background.paper};
+  color: ${p => (p.active ? p.theme.colors.wallet : p.theme.colors.palette.divider)};
+`;
+
+const SearchInput: ThemedComponent<{}> = styled.input`
+  border: none;
+  background: transparent;
+  outline: none;
+  flex-grow: 1;
+  font-family: "Inter";
+  cursor: text;
+  color: ${p => p.theme.colors.palette.text.shade100};
+  &::placeholder {
+    color: #999999;
+    font-weight: 500;
+  }
+`;
+
+const SearchIconContainer: ThemedComponent<{ focused?: boolean }> = styled(Box).attrs(p => ({
+  style: {
+    color: p.focused ? p.theme.colors.palette.text.shade100 : p.theme.colors.palette.text.shade40,
+  },
+}))`
+  justify-content: center;
+`;
+
+const Header = ({ onModeChange, onTextChange, onRangeChange, mode, search, range }: Props) => {
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <GenericBox horizontal p={0} alignItems="center">
+      <SearchIconContainer pr={3} focused={focused || !!search}>
+        <SearchIcon size={16} />
+      </SearchIconContainer>
+      <SearchInput
+        autoFocus
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder="Search"
+        onChange={onTextChange}
+        value={search}
+      />
+      <AccountsRange onRangeChange={onRangeChange} range={range} />
+      <Box ml={4} mr={4}>
+        <AccountsOrder />
+      </Box>
+      <ToggleButton mr={1} onClick={() => onModeChange("list")} active={mode === "list"}>
+        <ListIcon />
+      </ToggleButton>
+      <ToggleButton onClick={() => onModeChange("card")} active={mode === "card"}>
+        <GridIcon />
+      </ToggleButton>
+    </GenericBox>
+  );
+};
+
+export default Header;

--- a/src/renderer/screens/accounts/AccountList/ListBody.js
+++ b/src/renderer/screens/accounts/AccountList/ListBody.js
@@ -1,0 +1,54 @@
+// @flow
+
+import React from "react";
+import type { TokenAccount, Account, PortfolioRange } from "@ledgerhq/live-common/lib/types";
+import Box from "~/renderer/components/Box";
+import AccountItem from "../AccountRowItem";
+import AccountItemPlaceholder from "../AccountRowItem/Placeholder";
+
+type Props = {
+  visibleAccounts: Account[],
+  hiddenAccounts: Account[],
+  onAccountClick: (Account | TokenAccount) => void,
+  lookupParentAccount: (id: string) => ?Account,
+  range: PortfolioRange,
+  showNewAccount: boolean,
+  search?: string,
+};
+
+const ListBody = ({
+  visibleAccounts,
+  showNewAccount,
+  hiddenAccounts,
+  range,
+  onAccountClick,
+  lookupParentAccount,
+  search,
+}: Props) => (
+  <Box>
+    {visibleAccounts.map(account => (
+      <AccountItem
+        key={account.id}
+        account={account}
+        search={search}
+        parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
+        range={range}
+        onClick={onAccountClick}
+      />
+    ))}
+    {showNewAccount ? <AccountItemPlaceholder /> : null}
+    {hiddenAccounts.map(account => (
+      <AccountItem
+        hidden
+        key={account.id}
+        account={account}
+        search={search}
+        parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
+        range={range}
+        onClick={onAccountClick}
+      />
+    ))}
+  </Box>
+);
+
+export default ListBody;

--- a/src/renderer/screens/accounts/AccountList/Order.js
+++ b/src/renderer/screens/accounts/AccountList/Order.js
@@ -1,0 +1,103 @@
+// @flow
+import React, { useCallback } from "react";
+import { Trans } from "react-i18next";
+import { connect } from "react-redux";
+import { createStructuredSelector } from "reselect";
+
+import { refreshAccountsOrdering } from "~/renderer/actions/general";
+import { saveSettings } from "~/renderer/actions/settings";
+import Track from "~/renderer/analytics/Track";
+import BoldToggle from "~/renderer/components/BoldToggle";
+import Box from "~/renderer/components/Box";
+import DropDown, { DropDownItem } from "~/renderer/components/DropDown";
+import type { DropDownItemType } from "~/renderer/components/DropDown";
+import Text from "~/renderer/components/Text";
+import IconAngleDown from "~/renderer/icons/AngleDown";
+import { getOrderAccounts } from "~/renderer/reducers/settings";
+
+const items = ["balance|desc", "balance|asc", "name|asc", "name|desc"].map(key => ({
+  key,
+  label: <Trans i18nKey={`accounts.order.${key}`} />,
+}));
+
+type Props = {
+  orderAccounts: string,
+  refreshAccountsOrdering: () => *,
+  saveSettings: (*) => *,
+};
+
+const Order = ({ orderAccounts, saveSettings, refreshAccountsOrdering }: Props) => {
+  const onChange = useCallback(
+    o => {
+      if (!o) return;
+      saveSettings({ orderAccounts: o.key });
+      refreshAccountsOrdering();
+    },
+    [saveSettings, refreshAccountsOrdering],
+  );
+
+  const renderItem = useCallback(props => <OrderItem {...props} />, []);
+
+  const value = items.find(item => item.key === orderAccounts);
+
+  return (
+    <DropDown
+      flow={1}
+      offsetTop={2}
+      horizontal
+      items={items}
+      renderItem={renderItem}
+      onChange={onChange}
+      value={value}
+    >
+      <Track onUpdate event="ChangeSort" orderAccounts={orderAccounts} />
+      <Text ff="Inter|SemiBold" fontSize={4}>
+        <Trans i18nKey="common.sortBy" />
+      </Text>
+      <Box alignItems="center" color="wallet" ff="Inter|SemiBold" flow={1} fontSize={4} horizontal>
+        <Text color="wallet">
+          <Trans i18nKey={`accounts.order.${orderAccounts}`} />
+        </Text>
+        <IconAngleDown size={16} />
+      </Box>
+    </DropDown>
+  );
+};
+
+type ItemProps = {
+  item: DropDownItemType,
+  isHighlighted: boolean,
+  isActive: boolean,
+};
+
+const OrderItem: React$ComponentType<ItemProps> = React.memo(function OrderItem({
+  item,
+  isHighlighted,
+  isActive,
+}: ItemProps) {
+  return (
+    <DropDownItem
+      alignItems="center"
+      justifyContent="flex-start"
+      horizontal
+      isHighlighted={isHighlighted}
+      isActive={isActive}
+      flow={2}
+    >
+      <BoldToggle isBold={isActive}>{item.label}</BoldToggle>
+    </DropDownItem>
+  );
+});
+
+const mapStateToProps = createStructuredSelector({
+  orderAccounts: getOrderAccounts,
+});
+
+const mapDispatchToProps = {
+  refreshAccountsOrdering,
+  saveSettings,
+};
+
+const ConnectedOrder: React$ComponentType<{}> = connect(mapStateToProps, mapDispatchToProps)(Order);
+
+export default ConnectedOrder;

--- a/src/renderer/screens/accounts/AccountList/Range.js
+++ b/src/renderer/screens/accounts/AccountList/Range.js
@@ -1,0 +1,91 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import type { PortfolioRange } from "@ledgerhq/live-common/lib/types/portfolio";
+
+import Track from "~/renderer/analytics/Track";
+import BoldToggle from "~/renderer/components/BoldToggle";
+import Box from "~/renderer/components/Box";
+import DropDown, { DropDownItem } from "~/renderer/components/DropDown";
+import type { DropDownItemType } from "~/renderer/components/DropDown";
+import Text from "~/renderer/components/Text";
+import IconAngleDown from "~/renderer/icons/AngleDown";
+
+type Props = {
+  onRangeChange: PortfolioRange => void,
+  range?: PortfolioRange,
+};
+
+const renderItem = ({
+  item,
+  isHighlighted,
+  isActive,
+}: {
+  item: DropDownItemType,
+  isHighlighted: boolean,
+  isActive: boolean,
+}) => (
+  <DropDownItem
+    alignItems="center"
+    justifyContent="flex-start"
+    horizontal
+    isHighlighted={isHighlighted}
+    isActive={isActive}
+    flow={2}
+  >
+    <Box grow alignItems="flex-start">
+      <BoldToggle isBold={isActive}>{item.label}</BoldToggle>
+    </Box>
+  </DropDownItem>
+);
+
+const Range = ({ range, ...props }: Props) => {
+  const { t } = useTranslation();
+
+  const rangeItems = [
+    {
+      key: "week",
+      label: t("accounts.range.week"),
+    },
+    {
+      key: "month",
+      label: t("accounts.range.month"),
+    },
+    {
+      key: "year",
+      label: t("accounts.range.year"),
+    },
+  ];
+
+  const onRangeChange = ({ selectedItem: item }) => {
+    if (!item) {
+      return;
+    }
+    props.onRangeChange(item.key);
+  };
+
+  return (
+    <DropDown
+      flow={1}
+      offsetTop={2}
+      horizontal
+      items={rangeItems}
+      renderItem={renderItem}
+      onStateChange={onRangeChange}
+      value={rangeItems.find(item => item.key === range)}
+    >
+      <Track onUpdate event="ChangeRange" range={rangeItems} />
+      <Text color="palette.text.shade60" ff="Inter|SemiBold" fontSize={4}>
+        {t("common.range")}
+      </Text>
+      <Box alignItems="center" color="wallet" ff="Inter|SemiBold" flow={1} fontSize={4} horizontal>
+        <Text color="wallet">{t(`accounts.range.${range || "week"}`)}</Text>
+        <IconAngleDown size={16} />
+      </Box>
+    </DropDown>
+  );
+};
+
+export default Range;

--- a/src/renderer/screens/accounts/AccountList/index.js
+++ b/src/renderer/screens/accounts/AccountList/index.js
@@ -1,0 +1,132 @@
+// @flow
+
+import React, { Component } from "react";
+import { Trans } from "react-i18next";
+import {
+  getAccountCurrency,
+  getAccountName,
+  listSubAccounts,
+} from "@ledgerhq/live-common/lib/account/helpers";
+import type {
+  Account,
+  AccountLike,
+  PortfolioRange,
+  TokenAccount,
+} from "@ledgerhq/live-common/lib/types";
+
+import StickyBackToTop from "~/renderer/components/StickyBackToTop";
+import Text from "~/renderer/components/Text";
+
+import AccountListHeader from "./Header";
+import GridBody from "./GridBody";
+import ListBody from "./ListBody";
+
+type Props = {
+  accounts: (Account | TokenAccount)[],
+  mode: *,
+  onModeChange: (*) => void,
+  onRangeChange: PortfolioRange => void,
+  onAccountClick: (Account | TokenAccount, ?Account) => void,
+  range: PortfolioRange,
+};
+
+type State = {
+  search: string,
+};
+
+const BodyByMode = {
+  card: GridBody,
+  list: ListBody,
+};
+
+export const matchesSearch = (
+  search?: string,
+  account: AccountLike,
+  subMatch: boolean = false,
+): boolean => {
+  if (!search) return true;
+  let match;
+
+  if (account.type === "Account") {
+    match = `${account.currency.ticker}|${account.currency.name}|${getAccountName(account)}`;
+    subMatch =
+      subMatch &&
+      !!account.subAccounts &&
+      listSubAccounts(account).some(token => matchesSearch(search, token));
+  } else {
+    const c = getAccountCurrency(account);
+    match = `${c.ticker}|${c.name}|${getAccountName(account)}`;
+  }
+
+  return match.toLowerCase().includes(search.toLowerCase()) || subMatch;
+};
+
+class AccountList extends Component<Props, State> {
+  state = {
+    search: "",
+  };
+
+  lookupParentAccount = (id: string): ?Account => {
+    for (const a of this.props.accounts) {
+      if (a.type === "Account" && a.id === id) {
+        return a;
+      }
+    }
+    return null;
+  };
+
+  onTextChange = (evt: SyntheticInputEvent<HTMLInputElement>) =>
+    this.setState({
+      search: evt.target.value,
+    });
+
+  render() {
+    const { accounts, range, onAccountClick, onModeChange, onRangeChange, mode } = this.props;
+    const { search } = this.state;
+    const Body = BodyByMode[mode];
+
+    const visibleAccounts = [];
+    const hiddenAccounts = [];
+    for (let i = 0; i < accounts.length; i++) {
+      const account = accounts[i];
+      if (matchesSearch(search, account, mode === "list")) {
+        visibleAccounts.push(account);
+      } else {
+        hiddenAccounts.push(account);
+      }
+    }
+
+    return (
+      <div style={{ paddingBottom: 70 }}>
+        <AccountListHeader
+          onTextChange={this.onTextChange}
+          onModeChange={onModeChange}
+          onRangeChange={onRangeChange}
+          mode={mode}
+          range={range}
+          search={search}
+          accountsLength={accounts.length}
+        />
+        {visibleAccounts.length === 0 ? (
+          <Text style={{ display: "block", padding: 60, textAlign: "center" }}>
+            <Trans i18nKey="accounts.noResultFound" />
+          </Text>
+        ) : null}
+        <Body
+          horizontal
+          data-e2e="dashboard_AccountList"
+          range={range}
+          search={search}
+          visibleAccounts={visibleAccounts}
+          hiddenAccounts={hiddenAccounts}
+          showNewAccount={!search}
+          onAccountClick={onAccountClick}
+          lookupParentAccount={this.lookupParentAccount}
+        />
+        <StickyBackToTop scrollUpOnMount />
+      </div>
+    );
+  }
+}
+
+export default AccountList;

--- a/src/renderer/screens/accounts/AccountRowItem/Balance.js
+++ b/src/renderer/screens/accounts/AccountRowItem/Balance.js
@@ -1,0 +1,33 @@
+// @flow
+
+import type { BigNumber } from "bignumber.js";
+import React, { PureComponent } from "react";
+import type { Unit } from "@ledgerhq/live-common/lib/types";
+import Box from "~/renderer/components/Box";
+import FormattedVal from "~/renderer/components/FormattedVal";
+
+class Balance extends PureComponent<{
+  unit: Unit,
+  balance: BigNumber,
+  disableRounding?: boolean,
+}> {
+  render() {
+    const { unit, balance, disableRounding } = this.props;
+    return (
+      <Box flex="30%" justifyContent="center" fontSize={4}>
+        <FormattedVal
+          alwaysShowSign={false}
+          animateTicker={false}
+          ellipsis
+          color="palette.text.shade100"
+          unit={unit}
+          showCode
+          val={balance}
+          disableRounding={disableRounding}
+        />
+      </Box>
+    );
+  }
+}
+
+export default Balance;

--- a/src/renderer/screens/accounts/AccountRowItem/Countervalue.js
+++ b/src/renderer/screens/accounts/AccountRowItem/Countervalue.js
@@ -1,0 +1,59 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { connect } from "react-redux";
+import { createStructuredSelector } from "reselect";
+import type {
+  BalanceHistoryWithCountervalue,
+  CryptoCurrency,
+  TokenCurrency,
+} from "@ledgerhq/live-common/lib/types";
+
+import { balanceHistoryWithCountervalueSelector } from "~/renderer/actions/portfolio";
+import Box from "~/renderer/components/Box";
+import CounterValue from "~/renderer/components/CounterValue";
+import { PlaceholderLine } from "~/renderer/components/Placeholder";
+
+type OwnProps = {
+  currency: CryptoCurrency | TokenCurrency,
+};
+
+type Props = OwnProps & {
+  histo: {
+    history: BalanceHistoryWithCountervalue,
+    countervalueAvailable: boolean,
+  },
+};
+class Countervalue extends PureComponent<Props> {
+  render() {
+    const { histo, currency } = this.props;
+    const balanceEnd = histo.history[histo.history.length - 1].value;
+    const placeholder = <PlaceholderLine width={16} height={2} />;
+    return (
+      <Box flex="20%">
+        {histo.countervalueAvailable ? (
+          <CounterValue
+            currency={currency}
+            value={balanceEnd}
+            animateTicker={false}
+            alwaysShowSign={false}
+            showCode
+            fontSize={3}
+            color="palette.text.shade80"
+            placeholder={placeholder}
+          />
+        ) : (
+          placeholder
+        )}
+      </Box>
+    );
+  }
+}
+
+const ConnectedCountervalue: React$ComponentType<OwnProps> = connect(
+  createStructuredSelector({
+    histo: balanceHistoryWithCountervalueSelector,
+  }),
+)(Countervalue);
+
+export default ConnectedCountervalue;

--- a/src/renderer/screens/accounts/AccountRowItem/Delta.js
+++ b/src/renderer/screens/accounts/AccountRowItem/Delta.js
@@ -1,0 +1,43 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { connect } from "react-redux";
+import { createStructuredSelector } from "reselect";
+import type { AccountPortfolio } from "@ledgerhq/live-common/lib/types";
+
+import { balanceHistoryWithCountervalueSelector } from "~/renderer/actions/portfolio";
+import Box from "~/renderer/components/Box";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import { PlaceholderLine } from "~/renderer/components/Placeholder";
+
+class Delta extends PureComponent<{
+  histo: AccountPortfolio,
+}> {
+  render() {
+    const {
+      histo: { countervalueChange },
+    } = this.props;
+    return (
+      <Box flex="10%" justifyContent="flex-end">
+        {!countervalueChange.percentage ? (
+          <PlaceholderLine width={16} height={2} />
+        ) : (
+          <FormattedVal
+            isPercent
+            val={countervalueChange.percentage.times(100).integerValue()}
+            alwaysShowSign
+            fontSize={3}
+          />
+        )}
+      </Box>
+    );
+  }
+}
+
+const ConnectedDelta: React$ComponentType<{}> = connect(
+  createStructuredSelector({
+    histo: balanceHistoryWithCountervalueSelector,
+  }),
+)(Delta);
+
+export default ConnectedDelta;

--- a/src/renderer/screens/accounts/AccountRowItem/Header.js
+++ b/src/renderer/screens/accounts/AccountRowItem/Header.js
@@ -1,0 +1,62 @@
+// @flow
+
+import React from "react";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/lib/account";
+import type { AccountLike } from "@ledgerhq/live-common/lib/types/account";
+import styled from "styled-components";
+import useTheme from "~/renderer/hooks/useTheme";
+import Box from "~/renderer/components/Box";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import Tooltip from "~/renderer/components/Tooltip";
+import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
+
+type Props = {
+  account: AccountLike,
+  nested?: boolean,
+};
+
+// NB Inside Head to not break alignment with parent row;
+// and this is in fact not seen, because we draw on top
+// from AccountRowItem/index.js TokenBarIndicator
+const NestedIndicator = styled.div`
+  height: 44px;
+  width: 14px;
+`;
+
+const Header = ({ account, nested }: Props) => {
+  const theme = useTheme();
+  const currency = getAccountCurrency(account);
+  const name = getAccountName(account);
+  const color =
+    currency.type === "CryptoCurrency" ? currency.color : theme.colors.palette.text.shade60;
+  const title = currency.type === "CryptoCurrency" ? currency.name : "token";
+  return (
+    <Box
+      horizontal
+      ff="Inter|SemiBold"
+      flow={3}
+      flex={`${nested ? 42 : 30}%`}
+      pr={1}
+      alignItems="center"
+    >
+      {nested && <NestedIndicator />}
+      <Box alignItems="center" justifyContent="center" style={{ color }}>
+        <CryptoCurrencyIcon currency={currency} size={20} />
+      </Box>
+      <Box style={{ flexShrink: 1 }}>
+        {!nested && account.type === "Account" && (
+          <Box style={{ textTransform: "uppercase" }} fontSize={9} color="palette.text.shade60">
+            {title}
+          </Box>
+        )}
+        <Tooltip delay={1200} content={name}>
+          <Ellipsis fontSize={12} color="palette.text.shade100">
+            {name}
+          </Ellipsis>
+        </Tooltip>
+      </Box>
+    </Box>
+  );
+};
+
+export default Header;

--- a/src/renderer/screens/accounts/AccountRowItem/Placeholder.js
+++ b/src/renderer/screens/accounts/AccountRowItem/Placeholder.js
@@ -1,0 +1,53 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import styled from "styled-components";
+
+import { openModal } from "~/renderer/actions/modals";
+import Box from "~/renderer/components/Box";
+import IconPlus from "~/renderer/icons/Plus";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const AddAccountButton: ThemedComponent<{}> = styled.div`
+  border: 1px dashed rgba(153, 153, 153, 0.3);
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 20px;
+  color: #abadb6;
+  font-weight: 600;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: row;
+  height: auto;
+
+  &:hover {
+    cursor: pointer;
+    border-color: ${p => p.theme.colors.palette.text.shade100};
+    color: ${p => p.theme.colors.palette.text.shade100};
+  }
+`;
+
+const Placeholder = () => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return (
+    <Box mb={5}>
+      <AddAccountButton
+        isAccountRow
+        onClick={() => dispatch(openModal("MODAL_ADD_ACCOUNTS"))}
+        pb={6}
+      >
+        <IconPlus size={16} mr={20} />
+        <Box ml={2} ff="Inter|Regular" fontSize={4}>
+          {t("addAccounts.cta.add")}
+        </Box>
+      </AddAccountButton>
+    </Box>
+  );
+};
+
+export default Placeholder;

--- a/src/renderer/screens/accounts/AccountRowItem/index.js
+++ b/src/renderer/screens/accounts/AccountRowItem/index.js
@@ -1,0 +1,277 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { listSubAccounts } from "@ledgerhq/live-common/lib/account/helpers";
+import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/lib/currencies";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types/account";
+import type { PortfolioRange } from "@ledgerhq/live-common/lib/types/portfolio";
+
+import Box from "~/renderer/components/Box";
+import AccountContextMenu from "~/renderer/components/ContextMenu/AccountContextMenu";
+import Text from "~/renderer/components/Text";
+import IconAngleDown from "~/renderer/icons/AngleDown";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+import { matchesSearch } from "../AccountList";
+import AccountSyncStatusIndicator from "../AccountSyncStatusIndicator";
+import Balance from "./Balance";
+import Countervalue from "./Countervalue";
+import Delta from "./Delta";
+import Header from "./Header";
+
+// TODO Port TokenRow
+// import TokenRow from "~/renderer/components/TokenRow";
+// TODO Port Stars
+// import Star from "~/renderer/components/Stars/Star";
+
+const Row: ThemedComponent<{}> = styled(Box)`
+  background: ${p => p.theme.colors.palette.background.paper};
+  border-radius: 4px;
+  border: 1px solid transparent;
+  box-shadow: 0 4px 8px 0 #00000007;
+  color: #abadb6;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  font-weight: 600;
+  justify-content: flex-start;
+  margin-bottom: 9px;
+  padding: 16px 20px;
+  position: relative;
+  transition: background-color ease-in-out 200ms;
+  :hover {
+    border-color: ${p => p.theme.colors.palette.text.shade20};
+  }
+  :active {
+    border-color: ${p => p.theme.colors.palette.text.shade20};
+    background: ${p => p.theme.colors.palette.action.hover};
+  }
+`;
+
+const RowContent: ThemedComponent<{ disabled?: boolean }> = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  opacity: ${p => (p.disabled ? 0.3 : 1)};
+  & * {
+    color: ${p => (p.disabled ? p.theme.colors.palette.text.shade100 : "auto")};
+    fill: ${p => (p.disabled ? p.theme.colors.palette.text.shade100 : "auto")};
+  }
+`;
+
+const TokenContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  margin-top: 20px;
+`;
+
+const TokenContentWrapper = styled.div`
+  position: relative;
+`;
+
+const TokenBarIndicator: ThemedComponent<{}> = styled.div`
+  width: 15px;
+  border-left: 1px solid ${p => p.theme.colors.palette.divider};
+  z-index: 2;
+  margin-left: 9px;
+  padding-left: 5px;
+  position: absolute;
+  left: 0;
+  height: 100%;
+  &:hover {
+    border-color: ${p => p.theme.colors.palette.text.shade60};
+  }
+`;
+
+const TokenShowMoreIndicator: ThemedComponent<{ expanded?: boolean }> = styled.div`
+  margin: 15px -20px -16px;
+  display: flex;
+  color: ${p => p.theme.colors.wallet};
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid ${p => p.theme.colors.palette.divider};
+  background: ${p => p.theme.colors.palette.background.paper};
+  border-radius: 0px 0px 4px 4px;
+  height: 32px;
+  text-align: center;
+
+  &:hover ${Text} {
+    text-decoration: underline;
+  }
+
+  > :nth-child(2) {
+    margin-left: 8px;
+    transform: rotate(${p => (p.expanded ? "180deg" : "0deg")});
+  }
+`;
+
+type Props = {
+  account: TokenAccount | Account,
+  parentAccount?: ?Account,
+  disableRounding?: boolean,
+  onClick: (Account | TokenAccount, ?Account) => void,
+  hidden?: boolean,
+  range: PortfolioRange,
+  search?: string,
+};
+
+type State = {
+  expanded: boolean,
+};
+
+const expandedStates: { [key: string]: boolean } = {};
+
+class AccountRowItem extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    const { account, parentAccount } = this.props;
+    const accountId = parentAccount ? parentAccount.id : account.id;
+
+    this.state = {
+      expanded: expandedStates[accountId],
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps: Props) {
+    const { account } = nextProps;
+    if (account.subAccounts) {
+      return {
+        expanded: expandedStates[account.id] || !!nextProps.search,
+      };
+    }
+    return null;
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (prevState.expanded !== this.state.expanded && !this.state.expanded) {
+      const { scrollTopFocusRef } = this;
+      if (scrollTopFocusRef.current) {
+        scrollTopFocusRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      }
+    }
+  }
+
+  scrollTopFocusRef: * = React.createRef();
+
+  onClick = () => {
+    const { account, parentAccount, onClick } = this.props;
+    onClick(account, parentAccount);
+  };
+
+  toggleAccordion = (e: SyntheticEvent<*>) => {
+    e.stopPropagation();
+    const { account } = this.props;
+    expandedStates[account.id] = !expandedStates[account.id];
+    this.setState({ expanded: expandedStates[account.id] });
+  };
+
+  render() {
+    const {
+      account,
+      parentAccount,
+      range,
+      hidden,
+      // onClick,
+      disableRounding,
+      search,
+    } = this.props;
+    const { expanded } = this.state;
+
+    let currency;
+    let unit;
+    let mainAccount;
+    let tokens;
+    let disabled;
+    let isToken;
+
+    if (account.type !== "Account") {
+      currency = account.token;
+      unit = account.token.units[0];
+      mainAccount = parentAccount;
+      isToken = mainAccount && listTokenTypesForCryptoCurrency(mainAccount.currency).length > 0;
+
+      if (!mainAccount) return null;
+    } else {
+      currency = account.currency;
+      unit = account.unit;
+      mainAccount = account;
+      tokens = listSubAccounts(account);
+      disabled = !matchesSearch(search, account);
+      isToken = listTokenTypesForCryptoCurrency(currency).length > 0;
+      if (tokens) tokens = tokens.filter(t => matchesSearch(search, t));
+    }
+
+    const showTokensIndicator = tokens && tokens.length > 0 && !hidden;
+
+    const translationMap = isToken
+      ? {
+          see: "tokensList.seeTokens",
+          hide: "tokensList.hideTokens",
+        }
+      : {
+          see: "subAccounts.seeSubAccounts",
+          hide: "subAccounts.hideSubAccounts",
+        };
+
+    return (
+      <div style={{ position: "relative" }} hidden={hidden}>
+        <span style={{ position: "absolute", top: -70 }} ref={this.scrollTopFocusRef} />
+        <Row expanded={expanded} tokens={showTokensIndicator} key={mainAccount.id}>
+          <AccountContextMenu account={account}>
+            <RowContent disabled={disabled} onClick={this.onClick}>
+              <Header account={account} name={mainAccount.name} />
+              <Box flex="12%">
+                <div>
+                  <AccountSyncStatusIndicator accountId={mainAccount.id} />
+                </div>
+              </Box>
+              <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
+              <Countervalue account={account} currency={currency} range={range} />
+              <Delta account={account} range={range} />
+              {/* <Star accountId={account.id} /> */}
+            </RowContent>
+          </AccountContextMenu>
+          {showTokensIndicator && expanded && (
+            <TokenContentWrapper>
+              <TokenBarIndicator onClick={this.toggleAccordion} />
+              <TokenContent>
+                {tokens &&
+                  tokens.map((token, index) => (
+                    <AccountContextMenu key={token.id} account={token} parentAccount={mainAccount}>
+                      <Box>TokenRow</Box>
+                      {/* <TokenRow
+                        nested
+                        index={index}
+                        range={range}
+                        account={token}
+                        parentAccount={mainAccount}
+                        onClick={onClick}
+                      /> */}
+                    </AccountContextMenu>
+                  ))}
+              </TokenContent>
+            </TokenContentWrapper>
+          )}
+          {showTokensIndicator && !disabled && tokens && (
+            <TokenShowMoreIndicator expanded={expanded} onClick={this.toggleAccordion}>
+              <Text color="wallet" ff="Inter|SemiBold" fontSize={4}>
+                <Trans
+                  i18nKey={translationMap[expanded ? "hide" : "see"]}
+                  values={{ tokenCount: tokens.length }}
+                />
+              </Text>
+              <IconAngleDown size={16} />
+            </TokenShowMoreIndicator>
+          )}
+        </Row>
+      </div>
+    );
+  }
+}
+
+export default AccountRowItem;

--- a/src/renderer/screens/accounts/AccountSyncStatusIndicator.js
+++ b/src/renderer/screens/accounts/AccountSyncStatusIndicator.js
@@ -1,0 +1,172 @@
+// @flow
+
+import React, { PureComponent, useCallback, useEffect, useRef, useState } from "react";
+import { Trans } from "react-i18next";
+import { connect, useDispatch } from "react-redux";
+import { createStructuredSelector } from "reselect";
+
+import Box from "~/renderer/components/Box";
+import { Rotating } from "~/renderer/components/Spinner";
+import Tooltip from "~/renderer/components/Tooltip";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import IconCheck from "~/renderer/icons/Check";
+import IconPending from "~/renderer/icons/Clock";
+import IconError from "~/renderer/icons/Error";
+import IconLoader from "~/renderer/icons/Loader";
+import IconWarning from "~/renderer/icons/TriangleWarning";
+import {
+  accountNeedsMigrationSelector,
+  isUpToDateAccountSelector,
+} from "~/renderer/reducers/accounts";
+import { colors } from "~/renderer/styles/theme";
+import { openModal } from "~/renderer/actions/modals";
+import { useBridgeSync } from "~/renderer/bridge/BridgeSyncContext";
+import { accountSyncStateSelector } from "~/renderer/reducers/bridgeSync";
+import type { AsyncState } from "~/renderer/reducers/bridgeSync";
+
+const mapStateToProps = createStructuredSelector({
+  syncState: accountSyncStateSelector,
+  isUpToDateAccount: isUpToDateAccountSelector,
+  needsMigration: accountNeedsMigrationSelector,
+});
+
+class StatusQueued extends PureComponent<{ onClick: (*) => void }> {
+  render() {
+    const { onClick } = this.props;
+    return (
+      <Tooltip content={<Trans i18nKey="common.sync.outdated" />}>
+        <Box onClick={onClick}>
+          <IconPending color={colors.grey} size={16} />
+        </Box>
+      </Tooltip>
+    );
+  }
+}
+
+class StatusSynchronizing extends PureComponent<{ onClick: (*) => void }> {
+  render() {
+    const { onClick } = this.props;
+    return (
+      <Tooltip content={<Trans i18nKey="common.sync.syncing" />}>
+        <Box onClick={onClick}>
+          <Rotating onClick={onClick} size={16}>
+            <IconLoader color={colors.grey} size={16} />
+          </Rotating>
+        </Box>
+      </Tooltip>
+    );
+  }
+}
+
+class StatusUpToDate extends PureComponent<{ onClick: (*) => void }> {
+  render() {
+    const { onClick } = this.props;
+    return (
+      <Tooltip content={<Trans i18nKey="common.sync.upToDate" />}>
+        <Box onClick={onClick}>
+          <IconCheck onClick={onClick} color={colors.positiveGreen} size={16} />
+        </Box>
+      </Tooltip>
+    );
+  }
+}
+
+class StatusError extends PureComponent<{ onClick: (*) => void, error: ?Error }> {
+  render() {
+    const { onClick, error } = this.props;
+    return (
+      <Tooltip
+        tooltipBg="alertRed"
+        content={
+          <Box style={{ maxWidth: 250 }}>
+            <TranslatedError error={error} />
+          </Box>
+        }
+      >
+        <Box onClick={onClick}>
+          <IconError onClick={onClick} color={colors.alertRed} size={16} />
+        </Box>
+      </Tooltip>
+    );
+  }
+}
+
+const StatusNeedsMigration = () => {
+  const dispatch = useDispatch();
+
+  const openMigrateAccountsModal = e => {
+    e.stopPropagation();
+    // TODO integrate migrate accounts modal
+    dispatch(openModal("MODAL_MIGRATE_ACCOUNTS"));
+  };
+
+  return (
+    <Tooltip content={<Trans i18nKey="common.sync.needsMigration" />}>
+      <Box onClick={openMigrateAccountsModal}>
+        <IconWarning onClick={openMigrateAccountsModal} color={colors.orange} size={16} />
+      </Box>
+    </Tooltip>
+  );
+};
+
+type OwnProps = {
+  accountId: string,
+};
+
+type Props = OwnProps & {
+  isUpToDateAccount: boolean,
+  needsMigration: boolean,
+  syncState: AsyncState,
+};
+
+const AccountSyncStatusIndicator = ({
+  accountId,
+  isUpToDateAccount,
+  needsMigration,
+  syncState: { pending, error },
+}: Props) => {
+  const setSyncBehavior = useBridgeSync();
+  const [userAction, setUserAction] = useState(false);
+  const timeout = useRef(null);
+  const onClick = useCallback(
+    e => {
+      e.stopPropagation();
+      setSyncBehavior({
+        type: "SYNC_ONE_ACCOUNT",
+        accountId,
+        priority: 10,
+      });
+      setUserAction(true);
+      // a user action is kept in memory for a short time (which will correspond to a spinner time)
+      clearTimeout(timeout.current);
+      timeout.current = setTimeout(() => setUserAction(false), 1000);
+    },
+    [setSyncBehavior, accountId],
+  );
+
+  // at unmount, clear all timeouts
+  useEffect(() => {
+    clearTimeout(timeout.current);
+  }, []);
+
+  if (needsMigration) {
+    return <StatusNeedsMigration onClick={onClick} />;
+  }
+  // We optimistically will show things are up to date even if it's actually synchronizing
+  // in order to "debounce" the UI and don't make it blinks each time a sync happens
+  // only when user did the account we will show the true state
+  if ((pending && !isUpToDateAccount) || userAction) {
+    return <StatusSynchronizing onClick={onClick} />;
+  }
+  if (error) {
+    return <StatusError onClick={onClick} error={error} />;
+  }
+  if (isUpToDateAccount) {
+    return <StatusUpToDate onClick={onClick} />;
+  }
+  return <StatusQueued onClick={onClick} />;
+};
+
+const m: React$ComponentType<OwnProps> = connect(mapStateToProps)(AccountSyncStatusIndicator);
+
+export default m;

--- a/src/renderer/screens/accounts/AccountsHeader.js
+++ b/src/renderer/screens/accounts/AccountsHeader.js
@@ -1,0 +1,48 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+
+import { openModal } from "~/renderer/actions/modals";
+
+import IconPlus from "~/renderer/icons/Plus";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+
+import OptionsButton from "./OptionsButton";
+
+const AccountsHeader = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  return (
+    <Box horizontal style={{ paddingBottom: 32 }}>
+      <Box
+        grow
+        ff="Inter|SemiBold"
+        fontSize={7}
+        color="palette.text.shade100"
+        data-e2e="accountsPage_title"
+      >
+        {t("accounts.title")}
+      </Box>
+      <Box horizontal flow={2} alignItems="center" justifyContent="flex-end">
+        <Button
+          small
+          primary
+          onClick={() => dispatch(openModal("MODAL_ADD_ACCOUNTS"))}
+          data-e2e="addAccount_button"
+        >
+          <Box horizontal flow={1} alignItems="center">
+            <IconPlus size={12} />
+            <Box>{t("addAccounts.cta.add")}</Box>
+          </Box>
+        </Button>
+        <OptionsButton />
+      </Box>
+    </Box>
+  );
+};
+
+export default AccountsHeader;

--- a/src/renderer/screens/accounts/EmptyState.js
+++ b/src/renderer/screens/accounts/EmptyState.js
@@ -1,0 +1,76 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
+import styled from "styled-components";
+
+import { openModal } from "~/renderer/actions/modals";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+// TODO rework Image component
+// import Image from "~/renderer/components/Image";
+
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const handleInstallApp = () => {
+  const { push } = useHistory();
+
+  push("/manager");
+};
+
+const EmptyState = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  return (
+    <Box alignItems="center" pb={8} style={{ margin: "auto" }}>
+      {/* <Image
+        alt="emptyState Dashboard logo"
+        resource="empty-state-accounts.svg"
+        width="500"
+        themeTyped
+      /> */}
+      <Box mt={5} alignItems="center">
+        <Title data-e2e="dashboard_empty_title">{t("emptyState.dashboard.title")}</Title>
+        <Description mt={3} style={{ maxWidth: 600 }}>
+          {t("emptyState.dashboard.desc")}
+        </Description>
+        <Box mt={5} horizontal style={{ width: 300 }} flow={3} justifyContent="center">
+          <Button
+            primary
+            style={{ minWidth: 120 }}
+            onClick={handleInstallApp}
+            data-e2e="dashboard_empty_OpenManager"
+          >
+            {t("emptyState.dashboard.buttons.installApp")}
+          </Button>
+          <Button
+            outline
+            style={{ minWidth: 120 }}
+            onClick={() => dispatch(openModal("MODAL_ADD_ACCOUNTS"))}
+            data-e2e="dashboard_empty_AddAccounts"
+          >
+            {t("emptyState.dashboard.buttons.addAccount")}
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export const Title: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  ff: "Inter|Regular",
+  fontSize: 6,
+  color: p => p.theme.colors.palette.text.shade100,
+}))``;
+
+export const Description: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  ff: "Inter|Regular",
+  fontSize: 4,
+  color: p => p.theme.colors.palette.text.shade80,
+  textAlign: "center",
+}))``;
+
+export default EmptyState;

--- a/src/renderer/screens/accounts/OptionsButton.js
+++ b/src/renderer/screens/accounts/OptionsButton.js
@@ -1,0 +1,137 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+
+import Track from "~/renderer/analytics/Track";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import DropDown, { DropDownItem } from "~/renderer/components/DropDown";
+import Switch from "~/renderer/components/Switch";
+import Tooltip from "~/renderer/components/Tooltip";
+import IconDots from "~/renderer/icons/Dots";
+import IconDownloadCloud from "~/renderer/icons/DownloadCloud";
+import IconSend from "~/renderer/icons/Send";
+import { hideEmptyTokenAccountsSelector } from "~/renderer/reducers/settings";
+import { openModal } from "~/renderer/actions/modals";
+import { setHideEmptyTokenAccounts } from "~/renderer/actions/settings";
+
+import type { DropDownItemType } from "~/renderer/components/DropDown";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const Separator: ThemedComponent<{}> = styled.div`
+  background-color: ${p => p.theme.colors.palette.divider};
+  height: 1px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+`;
+
+const Item: ThemedComponent<{
+  disableHover?: boolean,
+  isHighlighted?: boolean,
+}> = styled(DropDownItem)`
+  width: 230px;
+  cursor: pointer;
+  white-space: pre-wrap;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: ${p =>
+    !p.disableHover && p.isHighlighted && p.theme.colors.palette.background.default};
+`;
+
+type ItemType = DropDownItemType & {
+  icon?: React$Element<*>,
+  onClick?: Function,
+  type?: "separator",
+};
+
+const OptionsButton = () => {
+  const dispatch = useDispatch();
+  const hideEmptyTokenAccounts = useSelector(hideEmptyTokenAccountsSelector);
+  const { t } = useTranslation();
+
+  const items: DropDownItemType[] = [
+    {
+      key: "exportOperations",
+      label: t("accounts.optionsMenu.exportOperations"),
+      icon: <IconDownloadCloud size={16} />,
+      onClick: () => dispatch(openModal("MODAL_EXPORT_OPERATIONS")),
+    },
+    {
+      key: "exportAccounts",
+      label: t("accounts.optionsMenu.exportToMobile"),
+      icon: <IconSend size={16} />,
+      onClick: () => dispatch(openModal("MODAL_EXPORT_ACCOUNTS")),
+    },
+    {
+      key: "sep1",
+      type: "separator",
+      label: "",
+    },
+    {
+      key: "hideEmpty",
+      label: t("settings.accounts.hideEmptyTokens.title"),
+      onClick: (e: MouseEvent) => {
+        e.preventDefault();
+        dispatch(setHideEmptyTokenAccounts(!hideEmptyTokenAccounts));
+      },
+    },
+  ];
+
+  const renderItem = ({ item, isHighlighted }: { item: ItemType, isHighlighted: boolean }) => {
+    if (item.type === "separator") {
+      return <Separator />;
+    }
+
+    return (
+      <Item
+        horizontal
+        isHighlighted={isHighlighted}
+        flow={2}
+        onClick={item.onClick}
+        disableHover={item.key === "hideEmpty"}
+      >
+        {item.key === "hideEmpty" ? (
+          <Box mr={4}>
+            <Track
+              onUpdate
+              event={
+                hideEmptyTokenAccounts
+                  ? "hideEmptyTokenAccountsEnabled"
+                  : "hideEmptyTokenAccountsDisabled"
+              }
+            />
+            <Switch
+              isChecked={hideEmptyTokenAccounts}
+              onChange={newState => dispatch(setHideEmptyTokenAccounts(newState))}
+            />
+          </Box>
+        ) : item.icon ? (
+          <Box mr={4}>{item.icon}</Box>
+        ) : null}
+        {item.label}
+      </Item>
+    );
+  };
+
+  return (
+    <DropDown border horizontal offsetTop={2} items={items} renderItem={renderItem}>
+      <Tooltip content={t("accounts.optionsMenu.title")}>
+        <Button
+          small
+          outlineGrey
+          flow={1}
+          style={{ width: 34, padding: 0, justifyContent: "center" }}
+        >
+          <Box alignItems="center">
+            <IconDots size={14} />
+          </Box>
+        </Button>
+      </Tooltip>
+    </DropDown>
+  );
+};
+
+export default OptionsButton;

--- a/src/renderer/screens/accounts/index.js
+++ b/src/renderer/screens/accounts/index.js
@@ -1,16 +1,112 @@
 // @flow
+
 import React from "react";
 import { connect } from "react-redux";
-import { openModal } from "~/renderer/actions/modals";
-import Button from "~/renderer/components/Button";
+import { useHistory } from "react-router-dom";
+import { createSelector, createStructuredSelector } from "reselect";
+import styled from "styled-components";
 
-const Accounts = ({ dispatch }: { dispatch: (*) => void }) => (
-  <>
-    <h1>Accounts</h1>
-    <Button onClick={() => dispatch(openModal("MODAL_ADD_ACCOUNTS"))}>Add Accounts</Button>
-  </>
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
+import type { PortfolioRange } from "@ledgerhq/live-common/lib/types/portfolio";
+
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import UpdateBanner from "~/renderer/components/Updater/Banner";
+import { TopBannerContainer } from "~/renderer/screens/dashboard";
+import { flattenSortAccountsEnforceHideEmptyTokenSelector } from "~/renderer/actions/general";
+import { setAccountsViewMode, setSelectedTimeRange } from "~/renderer/actions/settings";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+import { accountsViewModeSelector, selectedTimeRangeSelector } from "~/renderer/reducers/settings";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+import AccountList from "./AccountList";
+import AccountsHeader from "./AccountsHeader";
+import EmptyState from "./EmptyState";
+
+// TODO Restore MigrationBanner
+// import MigrationBanner from "~/renderer/modals/MigrateAccounts/Banner";
+
+type Props = {
+  accounts: (Account | TokenAccount)[],
+  range: PortfolioRange,
+  mode: *,
+  setAccountsViewMode: (*) => void,
+  setSelectedTimeRange: PortfolioRange => void,
+};
+
+const accountsOrFlattenAccountsSelector = createSelector(
+  accountsViewModeSelector,
+  accountsSelector,
+  flattenSortAccountsEnforceHideEmptyTokenSelector,
+  (mode, accounts, flattenedAccounts) => (mode === "card" ? flattenedAccounts : accounts),
 );
 
-const screen: React$ComponentType<{}> = connect()(Accounts);
+const mapStateToProps = createStructuredSelector({
+  accounts: accountsOrFlattenAccountsSelector,
+  mode: accountsViewModeSelector,
+  range: selectedTimeRangeSelector,
+});
 
-export default screen;
+const mapDispatchToProps = {
+  setAccountsViewMode,
+  setSelectedTimeRange,
+};
+
+export const GenericBox: ThemedComponent<{}> = styled(Box)`
+  background: ${p => p.theme.colors.palette.background.paper};
+  flex: 1;
+  padding: 10px 20px;
+  margin-bottom: 9px;
+  color: #abadb6;
+  font-weight: 600;
+  align-items: center;
+  justify-content: flex-start;
+  display: flex;
+  flex-direction: row;
+  border-radius: 4px;
+  box-shadow: 0 4px 8px 0 #00000007;
+`;
+
+const AccountsPage = (props: Props) => {
+  const history = useHistory();
+
+  const onAccountClick = (account: Account | TokenAccount, parentAccount: ?Account) =>
+    parentAccount
+      ? history.push(`/account/${parentAccount.id}/${account.id}`)
+      : history.push(`/account/${account.id}`);
+
+  const { accounts, mode, setAccountsViewMode, setSelectedTimeRange, range } = props;
+
+  if (accounts.length === 0) {
+    return (
+      <>
+        <TrackPage category="Accounts" accountsLength={accounts.length} />
+        <TopBannerContainer>
+          <UpdateBanner />
+          {/* <MigrationBanner /> */}
+        </TopBannerContainer>
+        <EmptyState />
+      </>
+    );
+  }
+
+  return (
+    <Box>
+      <TrackPage category="Accounts" accountsLength={accounts.length} />
+      <TopBannerContainer>{/* <MigrationBanner /> */}</TopBannerContainer>
+      <AccountsHeader />
+      <AccountList
+        onAccountClick={onAccountClick}
+        onRangeChange={setSelectedTimeRange}
+        onModeChange={setAccountsViewMode}
+        accounts={accounts}
+        range={range}
+        mode={mode}
+      />
+    </Box>
+  );
+};
+
+const m: React$ComponentType<{}> = connect(mapStateToProps, mapDispatchToProps)(AccountsPage);
+
+export default m;


### PR DESCRIPTION
AccountS screen, working but missing the following components to be complete:
- Stars ⭐️
- Empty state images (because `Image` component needs rework)
- Token rows (because _Morrow can do it_ ©️)
- Migration modal and banner
- Export accounts modal