### PR TITLE
Make export accounts a real modal

### DIFF
--- a/src/renderer/modals/ExportAccounts/index.js
+++ b/src/renderer/modals/ExportAccounts/index.js
@@ -10,37 +10,35 @@ import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import Exporter from "~/renderer/components/Exporter";
 
-type OwnProps = {
-  isOpen: boolean,
+type ModalRenderProps = {
   onClose: () => void,
-  accounts?: Account[],
+  data?: {
+    accounts?: Account[],
+  },
 };
 
-type Props = {
-  ...OwnProps,
-};
-
-const ExportAccountsModal = ({ isOpen, onClose, accounts }: Props) => {
+const ExportAccountsModal = () => {
   const { t } = useTranslation();
 
   return (
     <Modal
-      isOpened={isOpen}
-      onClose={onClose}
-      render={({ onClose }: any) => (
-        <ModalBody
-          onClose={onClose}
-          title={t("settings.export.modal.title")}
-          render={() => <Exporter accounts={accounts} />}
-          renderFooter={() => (
-            <Box>
-              <Button small onClick={onClose} primary>
-                <Trans i18nKey="settings.export.modal.button" />
-              </Button>
-            </Box>
-          )}
-        />
-      )}
+      name="MODAL_EXPORT_ACCOUNTS"
+      render={({ onClose, data }: ModalRenderProps) => {
+        return (
+          <ModalBody
+            onClose={onClose}
+            title={t("settings.export.modal.title")}
+            render={() => <Exporter {...data} />}
+            renderFooter={() => (
+              <Box>
+                <Button small onClick={onClose} primary>
+                  <Trans i18nKey="settings.export.modal.button" />
+                </Button>
+              </Box>
+            )}
+          />
+        );
+      }}
     />
   );
 };

--- a/src/renderer/modals/MigrateAccounts/steps/StepOverview.js
+++ b/src/renderer/modals/MigrateAccounts/steps/StepOverview.js
@@ -1,9 +1,11 @@
 // @flow
 
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useCallback } from "react";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 import reduce from "lodash/reduce";
+import { openModal } from "~/renderer/actions/modals";
 import { rgba } from "~/renderer/styles/helpers";
 import Button from "~/renderer/components/Button";
 import Box from "~/renderer/components/Box";
@@ -15,7 +17,6 @@ import IconExclamationCircle from "~/renderer/icons/ExclamationCircle";
 import AccountRow from "~/renderer/components/AccountsList/AccountRow";
 import IconExternalLink from "~/renderer/icons/ExternalLink";
 import { openURL } from "~/renderer/linking";
-import ExportAccountsModal from "~/renderer/modals/ExportAccounts";
 import { urls } from "~/config/urls";
 import type { StepProps } from "~/renderer/modals/MigrateAccounts";
 
@@ -169,16 +170,15 @@ const StepOverview = ({
   migratedAccounts,
 }: StepProps) => {
   const migratedAccountNames = Object.keys(migratedAccounts);
-  const [isExporting, setExporting] = useState(false);
+  const dispatch = useDispatch();
+  const openExportModal = useCallback(() => {
+    dispatch(
+      openModal("MODAL_EXPORT_ACCOUNTS", { accounts: getAllImportedAccounts(migratedAccounts) }),
+    );
+  }, [dispatch]);
 
   return (
     <Box alignItems="center">
-      <ExportAccountsModal
-        onClose={() => setExporting(false)}
-        isOpen={isExporting}
-        accounts={getAllImportedAccounts(migratedAccounts)}
-      />
-
       <TrackPage category="MigrateAccounts" name="Step1" />
 
       <Logo>
@@ -289,7 +289,7 @@ const StepOverview = ({
                 </MobileDesc>
               </MobileTextWrapper>
             </MobileContent>
-            <MobileCTA primary onClick={() => setExporting(true)}>
+            <MobileCTA primary onClick={openExportModal}>
               <Trans i18nKey="migrateAccounts.overview.mobileCTA" />
             </MobileCTA>
           </MobileWrapper>

--- a/src/renderer/modals/index.js
+++ b/src/renderer/modals/index.js
@@ -12,6 +12,7 @@ import MODAL_SEND from "./Send";
 import MODAL_UPDATE_FIRMWARE from "./UpdateFirmwareModal";
 import MODAL_OPERATION_DETAILS from "./OperationDetails";
 import MODAL_MIGRATE_ACCOUNTS from "./MigrateAccounts";
+import MODAL_EXPORT_ACCOUNTS from "./ExportAccounts";
 
 const modals: { [_: string]: React$ComponentType<any> } = {
   MODAL_EXPORT_OPERATIONS,
@@ -26,6 +27,7 @@ const modals: { [_: string]: React$ComponentType<any> } = {
   MODAL_OPERATION_DETAILS,
   MODAL_DELEGATE,
   MODAL_MIGRATE_ACCOUNTS,
+  MODAL_EXPORT_ACCOUNTS,
 };
 
 export default modals;

--- a/src/renderer/screens/settings/sections/Accounts/Export.js
+++ b/src/renderer/screens/settings/sections/Accounts/Export.js
@@ -18,7 +18,6 @@ const SectionExport = () => {
   const onModalOpen = useCallback(
     (e: SyntheticEvent<HTMLButtonElement>) => {
       e.preventDefault();
-      // TODO: ExportAccounts Modal
       dispatch(openModal("MODAL_EXPORT_ACCOUNTS"));
     },
     [dispatch],


### PR DESCRIPTION
We were using the modal in an embedded manner inside the overview step of migrating accounts, this should address it. ~Puting as a draft until I test again it works after migrating accounts~ Seems to work.

### Type

Code Quality Improvement