### PR TITLE
Fix broken scroll in selector

### DIFF
--- a/src/renderer/components/Select/index.js
+++ b/src/renderer/components/Select/index.js
@@ -207,6 +207,7 @@ class Select extends PureComponent<Props> {
         menuPlacement="auto"
         blurInputOnSelect={false}
         backspaceRemovesValue
+        captureMenuScroll={false}
         menuShouldBlockScroll
         menuPortalTarget={document.body}
         small={small}


### PR DESCRIPTION
We now need this since we are using a custom menu component and we handle the overflow ourselves. react-select seems to have a `ScrollCaptor` component that will not see the real size of our menu and hence prevent the scrolling. This fixes it.

