### PR TITLE
onboarding skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         run: |
           yarn --ignore-scripts
           yarn prepublish
-      - name: rebuild app deps
-        run: yarn install-deps
       - name: test
         run: yarn ci
   # ci-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         # we need to run yarn prepublish
         run: |
           yarn --ignore-scripts
-          yarn flow-typed
           yarn prepublish
       - name: test
         run: yarn ci
@@ -31,7 +30,6 @@ jobs:
       - name: install dependencies
         run: |
           yarn --ignore-scripts
-          yarn flow-typed
           yarn prepublish
       - name: rebuild app deps
         run: yarn install-deps

--- a/src/renderer/components/OnboardingOrElse.js
+++ b/src/renderer/components/OnboardingOrElse.js
@@ -4,7 +4,7 @@ import React, { memo } from "react";
 import { useSelector } from "react-redux";
 import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
 import { onboardingRelaunchedSelector } from "~/renderer/reducers/onboarding";
-import Onboarding from "~/renderer/screens/Onboarding";
+import Onboarding from "~/renderer/screens/onboarding";
 
 type Props = {
   children: React$Node,

--- a/src/renderer/components/OnboardingOrElse.js
+++ b/src/renderer/components/OnboardingOrElse.js
@@ -1,27 +1,26 @@
 // @flow
 
-// import React from "react";
-// import { useSelector } from "react-redux";
-// import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
-// import { onboardingRelaunchedSelector } from "~/renderer/reducers/onboarding";
-
-// TODO: ONBOARDING
-// import Onboarding from '~/renderer/components/Onboarding'
+import React, { memo } from "react";
+import { useSelector } from "react-redux";
+import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
+import { onboardingRelaunchedSelector } from "~/renderer/reducers/onboarding";
+import Onboarding from "~/renderer/screens/Onboarding";
 
 type Props = {
   children: React$Node,
 };
 
-const OnboardingOrElse = ({ children }: Props) => {
-  // const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  // const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
+const OnboardingOrElseC = ({ children }: Props) => {
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
 
-  // TODO: UNCOMMENT WHEN ONBOARDING IS DONE
-  // if (!hasCompletedOnboarding || onboardingRelaunched) {
-  //   return <h1>Onboarding</h1>
-  // }
+  if (!hasCompletedOnboarding || onboardingRelaunched) {
+    return <Onboarding />;
+  }
 
   return children;
 };
+
+const OnboardingOrElse: React$ComponentType<Props> = memo(OnboardingOrElseC);
 
 export default OnboardingOrElse;

--- a/src/renderer/components/OnboardingOrElse.js
+++ b/src/renderer/components/OnboardingOrElse.js
@@ -1,22 +1,23 @@
 // @flow
 
-import React, { memo } from "react";
-import { useSelector } from "react-redux";
-import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
-import { onboardingRelaunchedSelector } from "~/renderer/reducers/onboarding";
-import Onboarding from "~/renderer/screens/onboarding";
+import { memo } from "react";
+// import React, { memo } from "react";
+// import { useSelector } from "react-redux";
+// import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
+// import { onboardingRelaunchedSelector } from "~/renderer/reducers/onboarding";
+// import Onboarding from "~/renderer/screens/onboarding";
 
 type Props = {
   children: React$Node,
 };
 
 const OnboardingOrElseC = ({ children }: Props) => {
-  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
+  // const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  // const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
 
-  if (!hasCompletedOnboarding || onboardingRelaunched) {
-    return <Onboarding />;
-  }
+  // if (!hasCompletedOnboarding || onboardingRelaunched) {
+  //   return <Onboarding />;
+  // }
 
   return children;
 };

--- a/src/renderer/modals/MigrateAccounts/steps/StepOverview.js
+++ b/src/renderer/modals/MigrateAccounts/steps/StepOverview.js
@@ -124,9 +124,9 @@ const HelpLink = styled.span.attrs(() => ({
 const FooterContent = styled(Box).attrs(() => ({
   flow: 2,
   horizontal: true,
-  align: "center",
+  alignItems: "center",
 }))`
-  justify: flex-end;
+  justify-content: flex-end;
 `;
 
 const Exclamation = styled.div`

--- a/src/renderer/reducers/onboarding.js
+++ b/src/renderer/reducers/onboarding.js
@@ -3,7 +3,7 @@
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { handleActions } from "redux-actions";
 
-import { SKIP_ONBOARDING } from "../../config/constants";
+import { SKIP_ONBOARDING } from "~/config/constants";
 import type { State } from ".";
 
 type Step = {
@@ -180,6 +180,8 @@ const handlers = {
 };
 
 export default handleActions(handlers, initialState);
+
+export const onboardingSelector = (s: State): OnboardingState => s.onboarding;
 
 export const onboardingRelaunchedSelector = (s: State): ?boolean =>
   s.onboarding.onboardingRelaunched;

--- a/src/renderer/screens/onboarding/OnboardingBreadcrumb.js
+++ b/src/renderer/screens/onboarding/OnboardingBreadcrumb.js
@@ -1,0 +1,51 @@
+// @flow
+
+import React from "react";
+import { useSelector } from "react-redux";
+import findIndex from "lodash/findIndex";
+import { useTranslation } from "react-i18next";
+import type { OnboardingState } from "~/renderer/reducers/onboarding";
+import { onboardingSelector } from "~/renderer/reducers/onboarding";
+import Breadcrumb from "~/renderer/components/Stepper/Breadcrumb";
+
+const OnboardingBreadcrumb = () => {
+  const { t } = useTranslation();
+  const onboarding: OnboardingState = useSelector(onboardingSelector);
+  const { stepName, genuine, onboardingRelaunched } = onboarding;
+  const isInitializedFlow = onboarding.flowType === "initializedDevice";
+
+  const regularSteps = onboarding.steps
+    .filter(step => !step.external)
+    .map(step => ({ ...step, label: t(step.label) }));
+
+  const alreadyInitializedSteps = onboarding.steps
+    .filter(step => !step.external && !step.options.alreadyInitSkip)
+    .map(step => ({ ...step, label: t(step.label) }));
+
+  const onboardingRelaunchedSteps = onboarding.steps
+    .filter(step =>
+      isInitializedFlow
+        ? !step.options.alreadyInitSkip && !step.external && !step.options.relaunchSkip
+        : !step.external && !step.options.relaunchSkip,
+    )
+    .map(step => ({ ...step, label: t(step.label) }));
+
+  const filteredSteps = onboardingRelaunched
+    ? onboardingRelaunchedSteps
+    : isInitializedFlow
+    ? alreadyInitializedSteps
+    : regularSteps;
+
+  const stepIndex = findIndex(filteredSteps, s => s.name === stepName);
+  const genuineStepIndex = findIndex(filteredSteps, s => s.name === "genuineCheck");
+
+  return (
+    <Breadcrumb
+      stepsErrors={genuine.displayErrorScreen ? [genuineStepIndex] : undefined}
+      currentStep={stepIndex}
+      items={filteredSteps}
+    />
+  );
+};
+
+export default OnboardingBreadcrumb;

--- a/src/renderer/screens/onboarding/OnboardingFooter.js
+++ b/src/renderer/screens/onboarding/OnboardingFooter.js
@@ -1,0 +1,33 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import Button from "~/renderer/components/Button";
+import OnboardingFooterWrapper from "./OnboardingFooterWrapper";
+
+type Props = {
+  nextStep: () => void,
+  prevStep: () => void,
+  isContinueDisabled?: boolean,
+};
+
+const OnboardingFooter = ({ nextStep, prevStep, isContinueDisabled, ...props }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <OnboardingFooterWrapper {...props}>
+      <Button outlineGrey onClick={() => prevStep()}>
+        {t("common.back")}
+      </Button>
+      <Button
+        data-e2e="continue_button"
+        disabled={isContinueDisabled}
+        primary
+        onClick={() => nextStep()}
+        ml="auto"
+      >
+        {t("common.continue")}
+      </Button>
+    </OnboardingFooterWrapper>
+  );
+};
+export default OnboardingFooter;

--- a/src/renderer/screens/onboarding/OnboardingFooterWrapper.js
+++ b/src/renderer/screens/onboarding/OnboardingFooterWrapper.js
@@ -1,0 +1,18 @@
+// @flow
+import styled from "styled-components";
+import { radii } from "~/renderer/styles/theme";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import Box from "~/renderer/components/Box";
+
+const OnboardingFooterWrapper: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  px: 5,
+  py: 3,
+  horizontal: true,
+}))`
+  border-top: 2px solid ${p => p.theme.colors.palette.divider};
+  border-bottom-left-radius: ${radii[1]}px;
+  border-bottom-right-radius: ${radii[1]}px;
+  justify-content: space-between;
+`;
+
+export default OnboardingFooterWrapper;

--- a/src/renderer/screens/onboarding/index.js
+++ b/src/renderer/screens/onboarding/index.js
@@ -1,0 +1,218 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { compose } from "redux";
+import { withTranslation } from "react-i18next";
+import { connect } from "react-redux";
+import styled from "styled-components";
+import type { DeviceModelId } from "@ledgerhq/devices";
+import type { T } from "~/types/common";
+import type { OnboardingState } from "~/renderer/reducers/onboarding";
+import type { SettingsState } from "~/renderer/reducers/settings";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { onboardingRelaunchedSelector } from "~/renderer/reducers/onboarding";
+import {
+  nextStep,
+  prevStep,
+  jumpStep,
+  updateGenuineCheck,
+  deviceModelId,
+  flowType,
+  relaunchOnboarding,
+} from "~/renderer/actions/onboarding";
+import { saveSettings } from "~/renderer/actions/settings";
+import { openModal } from "~/renderer/actions/modals";
+import { unlock } from "~/renderer/actions/application";
+import Box from "~/renderer/components/Box";
+import ManagerConnect from "~/renderer/components/ManagerConnect";
+import IconCross from "~/renderer/icons/Cross";
+import Start from "./steps/Start";
+import InitStep from "./steps/Init";
+import NoDeviceStep from "./steps/NoDevice";
+import OnboardingBreadcrumb from "./OnboardingBreadcrumb";
+import SelectDevice from "./steps/SelectDevice";
+import SelectPIN from "./steps/SelectPIN/index";
+import WriteSeed from "./steps/WriteSeed/index";
+import SetPassword from "./steps/SetPassword";
+import Analytics from "./steps/Analytics";
+import Finish from "./steps/Finish";
+
+const STEPS = {
+  init: InitStep,
+  selectDevice: SelectDevice,
+  selectPIN: SelectPIN,
+  writeSeed: WriteSeed,
+  genuineCheck: ManagerConnect,
+  setPassword: SetPassword,
+  analytics: Analytics,
+  finish: Finish,
+  start: Start,
+  noDevice: NoDeviceStep,
+};
+
+const mapStateToProps = state => ({
+  hasCompletedOnboarding: state.settings.hasCompletedOnboarding,
+  onboardingRelaunched: onboardingRelaunchedSelector(state),
+  onboarding: state.onboarding,
+  settings: state.settings,
+  getCurrentDevice: getCurrentDevice(state),
+});
+
+const mapDispatchToProps = {
+  saveSettings,
+  nextStep,
+  prevStep,
+  jumpStep,
+  unlock,
+  openModal,
+  relaunchOnboarding,
+};
+
+type Props = {
+  t: T,
+  hasCompletedOnboarding: boolean,
+  onboardingRelaunched: boolean,
+  saveSettings: Function,
+  onboarding: OnboardingState,
+  settings: SettingsState,
+  prevStep: Function,
+  nextStep: Function,
+  jumpStep: Function,
+  getCurrentDevice: Function,
+  unlock: Function,
+  openModal: string => void,
+  relaunchOnboarding: boolean => void,
+};
+
+export type StepProps = {
+  t: T,
+  onboarding: OnboardingState,
+  settings: SettingsState,
+  prevStep: Function,
+  nextStep: Function,
+  jumpStep: Function,
+  finish: Function,
+  saveSettings: Function,
+  savePassword: Function,
+  getDeviceInfo: Function,
+  updateGenuineCheck: Function,
+  openModal: Function,
+  deviceModelId: DeviceModelId => *,
+  flowType: Function,
+};
+
+const CloseContainer = styled(Box).attrs(() => ({
+  p: 4,
+  color: "palette.divider",
+}))`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+
+  &:hover {
+    color: ${p => p.theme.colors.palette.text.shade60};
+  }
+
+  &:active {
+    color: ${p => p.theme.colors.palette.text.shade100};
+  }
+`;
+
+class OnboardingC extends PureComponent<Props> {
+  getDeviceInfo = () => this.props.getCurrentDevice;
+  cancelRelaunch = () => {
+    this.props.relaunchOnboarding(false);
+  };
+
+  finish = () => {
+    this.props.saveSettings({ hasCompletedOnboarding: true });
+    this.props.relaunchOnboarding(false);
+  };
+
+  savePassword = hash => {
+    this.props.saveSettings({
+      password: {
+        isEnabled: hash !== undefined,
+        value: hash,
+      },
+    });
+    this.props.unlock();
+  };
+
+  render() {
+    const {
+      onboarding,
+      prevStep,
+      nextStep,
+      jumpStep,
+      settings,
+      t,
+      onboardingRelaunched,
+    } = this.props;
+
+    const StepComponent = STEPS[onboarding.stepName];
+    const step = onboarding.steps[onboarding.stepIndex];
+
+    if (!StepComponent || !step) {
+      console.warn(`You reached an impossible onboarding step.`); // eslint-disable-line
+      return null;
+    }
+
+    const stepProps: StepProps = {
+      t,
+      onboarding,
+      settings,
+      updateGenuineCheck,
+      openModal,
+      deviceModelId,
+      flowType,
+      prevStep,
+      nextStep,
+      jumpStep,
+      finish: this.finish,
+      savePassword: this.savePassword,
+      getDeviceInfo: this.getDeviceInfo,
+      saveSettings,
+    };
+
+    return (
+      <Container>
+        {step.options.showBreadcrumb && <OnboardingBreadcrumb />}
+        {onboardingRelaunched ? (
+          <CloseContainer onClick={this.cancelRelaunch}>
+            <IconCross size={16} />
+          </CloseContainer>
+        ) : null}
+        <StepContainer>
+          <StepComponent {...stepProps} />
+        </StepContainer>
+      </Container>
+    );
+  }
+}
+
+const Container = styled(Box).attrs(() => ({
+  p: 60,
+  selectable: true,
+}))`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 25;
+  background-color: ${p => p.theme.colors.palette.background.paper};
+  transition: background-color ease-out 300ms;
+  transition-delay: 300ms;
+`;
+const StepContainer = styled(Box).attrs(() => ({
+  p: 40,
+}))``;
+
+const Onboarding: React$ComponentType<{}> = compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  withTranslation(),
+)(OnboardingC);
+
+export default Onboarding;

--- a/src/renderer/screens/onboarding/steps/Analytics.js
+++ b/src/renderer/screens/onboarding/steps/Analytics.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const Analytics = () => <div>Step Analytics</div>;
+
+export default Analytics;

--- a/src/renderer/screens/onboarding/steps/Finish.js
+++ b/src/renderer/screens/onboarding/steps/Finish.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const Finish = () => <div>Step Finish</div>;
+
+export default Finish;

--- a/src/renderer/screens/onboarding/steps/Init.js
+++ b/src/renderer/screens/onboarding/steps/Init.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const Init = () => <div>Step Init</div>;
+
+export default Init;

--- a/src/renderer/screens/onboarding/steps/NoDevice.js
+++ b/src/renderer/screens/onboarding/steps/NoDevice.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const NoDevice = () => <div>Step NoDevice</div>;
+
+export default NoDevice;

--- a/src/renderer/screens/onboarding/steps/SelectDevice.js
+++ b/src/renderer/screens/onboarding/steps/SelectDevice.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const SelectDevice = () => <div>Step SelectDevice</div>;
+
+export default SelectDevice;

--- a/src/renderer/screens/onboarding/steps/SelectPIN/index.js
+++ b/src/renderer/screens/onboarding/steps/SelectPIN/index.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const SelectPin = () => <div>Step SelectPin</div>;
+
+export default SelectPin;

--- a/src/renderer/screens/onboarding/steps/SetPassword.js
+++ b/src/renderer/screens/onboarding/steps/SetPassword.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const Password = () => <div>Step Password</div>;
+
+export default Password;

--- a/src/renderer/screens/onboarding/steps/Start.js
+++ b/src/renderer/screens/onboarding/steps/Start.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const Start = () => <div>Step Start</div>;
+
+export default Start;

--- a/src/renderer/screens/onboarding/steps/ThemeSelector.js
+++ b/src/renderer/screens/onboarding/steps/ThemeSelector.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const ThemeSelector = () => <div>Step ThemeSelector</div>;
+
+export default ThemeSelector;

--- a/src/renderer/screens/onboarding/steps/WriteSeed/index.js
+++ b/src/renderer/screens/onboarding/steps/WriteSeed/index.js
@@ -1,0 +1,6 @@
+// @flow
+import React from "react";
+
+const WriteSeed = () => <div>Step WriteSeed</div>;
+
+export default WriteSeed;


### PR DESCRIPTION
This is a starting point for Onboarding. The Steps are still empty
Some components from the old ./helperComponents.js have already been ported

- BulletRow (in `components/BulletRow.js`)
- OptionRowDesc (in `components/OpentRowDesc.js`)
- OnboardingFooterWrapper (in `screens/onboarding/OnboardingFooterWrapper.js`)

Starting from here, we can dispatch the steps between devs

To start the Onboarding process => Settings -> Help -> Device Setup 