### PR TITLE
LL-2128 Remove mention to terms of service on onboarding

### DIFF
--- a/src/renderer/i18n/en/app.json
+++ b/src/renderer/i18n/en/app.json
@@ -1165,10 +1165,6 @@
           "item2": "Ledger Live version, language and region",
           "item3": "OS version, language and region"
         }
-      },
-      "terms": {
-        "title": "Terms *",
-        "desc": "By continuing, you acknowledge that you have read and agree to the <1>Terms of Use</1> and <3>Privacy Policy</3>."
       }
     },
     "finish": {

--- a/src/renderer/screens/onboarding/steps/Analytics.js
+++ b/src/renderer/screens/onboarding/steps/Analytics.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { PureComponent } from "react";
 import { connect } from "react-redux";
-import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { urls } from "~/config/urls";
@@ -164,26 +163,6 @@ class Analytics extends PureComponent<StepProps, State> {
                 <Switch isChecked={sentryLogsToggle} onChange={this.handleSentryLogsToggle} />
               </Box>
             </Container>
-            <Container>
-              <Box>
-                <Box mb={1}>
-                  <AnalyticsTitle data-e2e="analytics_terms">
-                    {t("onboarding.analytics.terms.title")}
-                  </AnalyticsTitle>
-                </Box>
-                <AnalyticsText>
-                  <div>
-                    <Trans i18nKey="onboarding.analytics.terms.desc">
-                      {"Accept the "}
-                      <HoveredLink onClick={this.onClickTerms}>{"terms of license"}</HoveredLink>
-                      {"and"}
-                      <HoveredLink onClick={this.onClickPrivacy}>{"privacy"}</HoveredLink>
-                      {"."}
-                    </Trans>
-                  </div>
-                </AnalyticsText>
-              </Box>
-            </Container>
           </Box>
         </StepContainerInner>
         <OnboardingFooter
@@ -240,14 +219,6 @@ const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
 
 const LearnMoreWrapper = styled(Box)`
   ${FakeLink}:hover {
-    color: ${p => p.theme.colors.wallet};
-  }
-`;
-
-const HoveredLink = styled.span`
-  cursor: pointer;
-  text-decoration: underline;
-  &:hover {
     color: ${p => p.theme.colors.wallet};
   }
 `;


### PR DESCRIPTION
Removes the block in the analytics step of onboarding where we mentioned the terms of service since we've introduced a new modal that actually shows these terms of service and requires a user action to continue using the application.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2128

### Parts of the app affected / Test plan

Onboarding, analytics step, check the block is gone ☁️ 