### PR TITLE
LL-2105 Disable highlight for ModalHeaderActions if empty

### DIFF
--- a/src/renderer/components/Modal/ModalHeader.js
+++ b/src/renderer/components/Modal/ModalHeader.js
@@ -99,7 +99,7 @@ const ModalHeader = ({
           </Text>
         </ModalHeaderAction>
       ) : (
-        <ModalHeaderAction />
+        <div />
       )}
       <ModalTitle data-e2e="modalTitle">{children}</ModalTitle>
       {onClose ? (
@@ -107,7 +107,7 @@ const ModalHeader = ({
           <IconCross size={16} />
         </ModalHeaderAction>
       ) : (
-        <ModalHeaderAction />
+        <div />
       )}
     </div>
   );


### PR DESCRIPTION
We were incorrectly using an empty `ModalHeaderAction` component even when there was no `onBack` or `onClose` action provided for a modal. That component is the one that can be highlighted via the tab and it means that we would be highlighting an empty square in the header that did nothing.

The empty divs are needed to not break the layout of the header and keep the title and actions aligned.

### Type

UI Polish.

### Example of the unexpected behaviour
![image](https://user-images.githubusercontent.com/4631227/72268220-b8c59a80-3621-11ea-83ad-070216593f78.png)


### Context

https://ledgerhq.atlassian.net/browse/LL-2105

### Parts of the app affected / Test plan

Modals in general, tabbing to see the highlight element.