### PR TITLE
Hints perf cards (2s -> 100ms)

### DIFF
--- a/src/renderer/screens/accounts/AccountList/GridBody.js
+++ b/src/renderer/screens/accounts/AccountList/GridBody.js
@@ -36,27 +36,21 @@ const GridBody = ({
   ...rest
 }: Props) => (
   <GridBox {...rest}>
-    {visibleAccounts.map(account => (
-      <AccountCard
-        key={account.id}
-        account={account}
-        parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
-        range={range}
-        onClick={onAccountClick}
-      />
-    ))}
-    {showNewAccount ? <AccountCardPlaceholder key="placeholder" /> : null}
-    {hiddenAccounts.map(account => (
-      <AccountCard
-        hidden
-        key={account.id}
-        account={account}
-        parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
-        range={range}
-        onClick={onAccountClick}
-      />
-    ))}
+    {[...visibleAccounts, ...(showNewAccount ? [null] : []), ...hiddenAccounts].map((account, i) =>
+      !account ? (
+        <AccountCardPlaceholder key="placeholder" />
+      ) : (
+        <AccountCard
+          hidden={i >= visibleAccounts.length}
+          key={account.id}
+          account={account}
+          parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
+          range={range}
+          onClick={onAccountClick}
+        />
+      ),
+    )}
   </GridBox>
 );
 
-export default React.memo<Props>(GridBody);
+export default GridBody;


### PR DESCRIPTION
@MortalKastor i let you take over this subject

everything done in GridBody can also be backported in ListBody

this PR is to show the problem and a way to fix it but it's not necessarily the best code to fix it. need to see if there is an elegant solution. fact is, splitting the things in two array mapping make Rect reconciliation no longer working: I guess React reconciliate a same array, not siblings array of element.

also React.memo is not useful in GridBody and it's not free (it can makes perf a bit worse in case like this one)

I don't know if there is a more elegant way than what we are doing in the top level (splitting things in the two arrays) but the main goal was that we need to not unmount the cards but just hidding them in the dom. and to do this, we have to move them at the end in order for the grid alignment to work. we also want to add at the end of the visible grid item the placeholder. this PR makes it efficient for React but didn't change that idea ;)

---

a way to repro is simply to type "e" in search, we can see a lot of remounting is happening

2 seconds in total

<img width="724" alt="Capture d’écran 2020-01-14 à 09 47 22" src="https://user-images.githubusercontent.com/211411/72329791-adbc4a00-36b5-11ea-8ee5-cee4faecf60e.png">

after the fix

<img width="409" alt="Capture d’écran 2020-01-14 à 09 54 41" src="https://user-images.githubusercontent.com/211411/72329827-bc0a6600-36b5-11ea-8d5f-fefc4be69787.png">

which still show something is happening (in the format value?) so i think perf investigation can continue.

**We need to profile perf on all possible screens and action this week**