### PR TITLE
Fix glitch on parentCryptoCurrencyIcon

### DIFF
--- a/src/renderer/components/ParentCryptoCurrencyIcon.js
+++ b/src/renderer/components/ParentCryptoCurrencyIcon.js
@@ -29,7 +29,7 @@ const ParentCryptoCurrencyIconWrapper: ThemedComponent<{
   line-height: ${p => (p.bigger ? "18px" : "18px")};
   font-size: ${p => (p.bigger ? "12px" : "12px")};
   > :nth-child(2) {
-    margin-top: ${p => (p.bigger ? "-15px" : "-13px")};
+    margin-top: ${p => (p.bigger ? "-10px" : "-8px")};
     margin-left: ${p => (p.bigger ? "10px" : "8px")};
     border: 2px solid transparent;
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/72338094-0eeb1a00-36c4-11ea-8eea-f99e0ccd7b78.png)
(Now-Before, notice the overlap of the currency icon)
### Type

UI Polish
