### PR TITLE
LL-2129 Show a placeholder for assets without settings

### DIFF
--- a/src/renderer/i18n/en/app.json
+++ b/src/renderer/i18n/en/app.json
@@ -793,6 +793,7 @@
     },
     "currencies": {
       "desc": "Change settings for each of your crypto assets",
+      "placeholder": "No settings for this asset",
       "select": "Select a crypto asset to edit its settings.",
       "exchange": "Rate provider ({{ticker}} → BTC)",
       "exchangeDesc": "Choose the provider of the exchange rate from {{currencyName}} to Bitcoin, used to estimate the value of your crypto assets ({{ticker}} → BTC → {{fiat}}).",

--- a/src/renderer/screens/settings/sections/CryptoAssets/CurrencyRows.js
+++ b/src/renderer/screens/settings/sections/CryptoAssets/CurrencyRows.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { PureComponent } from "react";
-import { withTranslation } from "react-i18next";
+import { Trans, withTranslation } from "react-i18next";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
@@ -15,7 +15,8 @@ import {
 } from "~/renderer/reducers/settings";
 import type { SettingsState, CurrencySettings } from "~/renderer/reducers/settings";
 import StepperNumber from "~/renderer/components/StepperNumber";
-import { SettingsSectionRow as Row } from "../../SettingsSection";
+import { SettingsSectionRow as Row, SettingsSectionRowContainer } from "../../SettingsSection";
+import Box from "~/renderer/components/Box";
 
 type Props = {
   t: T,
@@ -57,6 +58,8 @@ class CurrencyRows extends PureComponent<Props> {
     const { currency, t, currencySettings } = this.props;
     const { confirmationsNb } = currencySettings;
     const defaults = currencySettingsDefaults(currency);
+    // NB ideally we would have a dynamic list of settings
+
     return (
       <>
         {defaults.confirmationsNb ? (
@@ -75,7 +78,13 @@ class CurrencyRows extends PureComponent<Props> {
               />
             ) : null}
           </Row>
-        ) : null}
+        ) : (
+          <SettingsSectionRowContainer>
+            <Box ff="Inter|SemiBold" color="palette.text.shade100" fontSize={4}>
+              <Trans i18nKey="settings.currencies.placeholder" />
+            </Box>
+          </SettingsSectionRowContainer>
+        )}
       </>
     );
   }


### PR DESCRIPTION
Show a placeholder text instead of nothing when selecting an asset for which we have no settings
![image](https://user-images.githubusercontent.com/4631227/72346078-84131b00-36d5-11ea-8121-bd0588fd38af.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2129
