### PR TITLE
progress streaming on send flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ledgerhq/hw-transport-http": "^5.6.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.6.0",
     "@ledgerhq/ledger-core": "^5.3.0",
-    "@ledgerhq/live-common": "^11.1.1",
+    "@ledgerhq/live-common": "^11.1.2",
     "@ledgerhq/logs": "^5.6.0",
     "@tippy.js/react": "^3.1.1",
     "animated": "^0.2.2",

--- a/src/renderer/hooks/useDebounce.js
+++ b/src/renderer/hooks/useDebounce.js
@@ -1,16 +1,23 @@
 // @flow
 import { useCallback, useEffect, useRef, useState } from "react";
 import debounce from "lodash/debounce";
+import throttle from "lodash/throttle";
 
-import type { DebounceOptions, Cancelable } from "lodash";
+import type { ThrottleOptions, DebounceOptions, Cancelable } from "lodash";
 
 export const useDebouncedCallback = (
   fn: (...args: any[]) => any,
-  delay: number = 0,
-  options: DebounceOptions,
+  delay: number,
+  options?: DebounceOptions,
 ): Function & Cancelable => useCallback(debounce(fn, delay, options), [fn, delay, options]);
 
-export const useDebounced = <T>(value: T, delay: number = 0, options: DebounceOptions): T => {
+export const useThrottledCallback = (
+  fn: (...args: any[]) => any,
+  delay: number,
+  options?: ThrottleOptions,
+): Function & Cancelable => useCallback(throttle(fn, delay, options), [fn, delay, options]);
+
+export const useDebounced = <T>(value: T, delay: number, options?: DebounceOptions): T => {
   const previousValue = useRef(value);
   const [current, setCurrent] = useState(value);
 

--- a/src/renderer/i18n/en/app.json
+++ b/src/renderer/i18n/en/app.json
@@ -615,7 +615,11 @@
         "unitPerByte": "{{unit}} per byte"
       },
       "verification": {
-        "title": "Verification"
+        "title": "Verification",
+        "streaming": {
+          "accurate": "Signing transaction ({{index}} of {{total}})",
+          "inaccurate": "Signing transaction..."
+        }
       },
       "confirmation": {
         "title": "Confirmation",
@@ -623,6 +627,10 @@
           "title": "Transaction sent",
           "text": "Your account balance will update once the blockchain has confirmed the transaction",
           "cta": "View details"
+        },
+        "streaming": {
+          "accurate": "Finalizing transaction ({{index}} of {{total}})",
+          "inaccurate": "Finalizing transaction..."
         },
         "pending": {
           "title": "Broadcasting transaction..."

--- a/src/renderer/modals/Send/Body.js
+++ b/src/renderer/modals/Send/Body.js
@@ -11,6 +11,7 @@ import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/lib/a
 import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
 import type { Account, AccountLike, Operation } from "@ledgerhq/live-common/lib/types";
 import logger from "~/logger";
+import { useThrottledCallback } from "~/renderer/hooks/useDebounce";
 import Stepper from "~/renderer/components/Stepper";
 import SyncSkipUnderPriority from "~/renderer/components/SyncSkipUnderPriority";
 import { closeModal, openModal } from "~/renderer/actions/modals";
@@ -186,6 +187,7 @@ const Body = ({
   );
 
   const handleRetry = useCallback(() => {
+    setSignOperationEvent(null);
     setTransactionError(null);
     setOptimisticOperation(null);
     setAppOpened(false);
@@ -217,11 +219,15 @@ const Body = ({
     [account, parentAccount, updateAccountWithUpdater],
   );
 
+  const [lastSignOperationEvent, setSignOperationEvent] = useState(null);
+  const onSignOperationEvent = useThrottledCallback(setSignOperationEvent, 100);
+
   const handleSignTransaction = useSignTransactionCallback({
     context: "Send",
     device,
     account,
     parentAccount,
+    onSignOperationEvent,
     handleOperationBroadcasted,
     transaction,
     handleTransactionError,
@@ -269,6 +275,7 @@ const Body = ({
     optimisticOperation,
     openModal,
     onClose,
+    lastSignOperationEvent,
     closeModal: handleCloseModal,
     onChangeAccount: handleChangeAccount,
     onChangeAppOpened: setAppOpened,

--- a/src/renderer/modals/Send/steps/StepConfirmation.js
+++ b/src/renderer/modals/Send/steps/StepConfirmation.js
@@ -59,6 +59,7 @@ const Disclaimer: ThemedComponent<{}> = styled(Box).attrs(() => ({
   color: ${p => p.theme.colors.alertRed};
 `;
 
+// TODO the "broadcasting" step need to be split out in another step, or at least a component
 function StepConfirmation({
   account,
   t,

--- a/src/renderer/modals/Send/steps/StepVerification.js
+++ b/src/renderer/modals/Send/steps/StepVerification.js
@@ -1,12 +1,34 @@
 // @flow
-
 import React, { PureComponent } from "react";
+import { Trans } from "react-i18next";
+import styled, { withTheme } from "styled-components";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import TrackPage from "~/renderer/analytics/TrackPage";
+import Spinner from "~/renderer/components/Spinner";
 import TransactionConfirm from "~/renderer/components/TransactionConfirm";
+import Box from "~/renderer/components/Box";
 
 import type { StepProps } from "../types";
 
-export default class StepVerification extends PureComponent<StepProps> {
+const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "palette.text.shade100",
+}))`
+  justify-content: center;
+  min-height: 220px;
+`;
+
+const Title: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  ff: "Inter",
+  fontSize: 5,
+  mt: 2,
+}))`
+  text-align: center;
+  word-break: break-word;
+`;
+
+class StepVerification extends PureComponent<StepProps & { theme: * }> {
   componentDidMount() {
     this.signTransaction();
   }
@@ -19,19 +41,53 @@ export default class StepVerification extends PureComponent<StepProps> {
   };
 
   render() {
-    const { device, account, parentAccount, transaction, status } = this.props;
+    const {
+      device,
+      account,
+      parentAccount,
+      transaction,
+      lastSignOperationEvent,
+      status,
+      theme,
+    } = this.props;
+
     if (!account || !device || !transaction) return null;
+
     return (
       <>
         <TrackPage category="Send Flow" name="Step Verification" />
-        <TransactionConfirm
-          device={device}
-          account={account}
-          parentAccount={parentAccount}
-          transaction={transaction}
-          status={status}
-        />
+        {lastSignOperationEvent && lastSignOperationEvent.type === "device-signature-requested" ? (
+          // we need to ask user to confirm the details
+          <TransactionConfirm
+            device={device}
+            account={account}
+            parentAccount={parentAccount}
+            transaction={transaction}
+            status={status}
+          />
+        ) : (
+          <Container>
+            <span style={{ color: theme.colors.palette.text.shade60 }}>
+              <Spinner size={43} />
+            </span>
+
+            <Title>
+              {lastSignOperationEvent && lastSignOperationEvent.type === "device-streaming" ? (
+                // with streaming event, we have accurate version of the wording
+                <Trans
+                  i18nKey="send.steps.verification.streaming.accurate"
+                  values={lastSignOperationEvent}
+                />
+              ) : (
+                // otherwise, we're not accurate (usually because we don't need to, it's fast case)
+                <Trans i18nKey="send.steps.verification.streaming.inaccurate" />
+              )}
+            </Title>
+          </Container>
+        )}
       </>
     );
   }
 }
+
+export default withTheme(StepVerification);

--- a/src/renderer/modals/Send/types.js
+++ b/src/renderer/modals/Send/types.js
@@ -7,6 +7,7 @@ import type {
   Transaction,
   TransactionStatus,
   Operation,
+  SignOperationEvent,
 } from "@ledgerhq/live-common/lib/types";
 import type { Device } from "~/renderer/reducers/devices";
 
@@ -34,6 +35,7 @@ export type StepProps = {
   bridgeError: ?Error,
   bridgePending: boolean,
   error: ?Error,
+  lastSignOperationEvent: ?SignOperationEvent,
   signed: boolean,
   optimisticOperation: ?Operation,
   closeModal: void => void,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,10 +1215,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.6.0.tgz#878851b961a34c1bda3618b3568b4e8faed532bd"
   integrity sha512-zdEYEsmfhFHv7f89srh7qI5XP0DIkV9xkONsE8dVHhqpoFx732yKozpVDFUp4zhaCCT/xNL5wbCDxM9edk6Uig==
 
-"@ledgerhq/hw-app-btc@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-5.6.0.tgz#cd72375303695936eaee2d3b1f5a60508c0aebcc"
-  integrity sha512-qFh1LQGtH9zAwtVW1LujUTCqov6wyX+m+Tt/2zdwiLxXUUXhOTqhGxReVe8QKnzoiH9wA+6XvzsB+TBGYahJwg==
+"@ledgerhq/hw-app-btc@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-5.6.1.tgz#86ccb3d44ae7c476f43b291514555cd71cfb4163"
+  integrity sha512-T6nQGYTFyMABlnwuP0QuLFh4Prw07Mn+ExMi9tjWXNImMQ093G1jt8GUKxdrXGuJ2rjHYCxi7UsgT5jYd7hiKA==
   dependencies:
     "@ledgerhq/hw-transport" "^5.6.0"
     bip32-path "^0.4.2"
@@ -1302,15 +1302,15 @@
     bindings "1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^11.1.1":
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.1.1.tgz#049e68082ca87658e909860aed56fd28c28e90d0"
-  integrity sha512-peUBQzQzem/mRbtKliRQP2MxwSHNkJQEKjCfMSjbwN6SuK8bjYcm47SrQ1BiKBA8NsdIYNOx6s9z7vKM4vnWVw==
+"@ledgerhq/live-common@^11.1.2":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.1.2.tgz#20d95d5bc8a1991346d12d09615cad73a9c63d97"
+  integrity sha512-CntPynivk3t24iXu77sjodHfODFDOiImLg/7rrA93PS50OmCv4lTVQEPhu312GBwg2reLT70wfVtIlOeTQCLOQ==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.6.0"
     "@ledgerhq/errors" "5.6.0"
-    "@ledgerhq/hw-app-btc" "5.6.0"
+    "@ledgerhq/hw-app-btc" "5.6.1"
     "@ledgerhq/hw-app-eth" "5.6.0"
     "@ledgerhq/hw-app-xrp" "5.6.0"
     "@ledgerhq/hw-transport" "5.6.0"


### PR DESCRIPTION

![signing](https://user-images.githubusercontent.com/211411/72755642-46c5f600-3bcb-11ea-9222-7950748cc47a.gif)

- The point of the feature is to no longer directly show the "please confirm on your device" UI but **only showing it when tx is actually appearing on the device**, which sometimes can take 10s.
- Similarly, after signing with the device, more exchange with the device is happening but it's pointless to continue showing "please confirm on your device" phase, so we enter again a loading phase (with another 10s potential and some progress event)
