### PR TITLE
Add the discreet mode feature leveraging live-common's support

### DIFF
--- a/src/renderer/actions/settings.js
+++ b/src/renderer/actions/settings.js
@@ -21,6 +21,7 @@ export const setAccountsViewMode = (accountsViewMode: *) => saveSettings({ accou
 export const setSelectedTimeRange = (selectedTimeRange: PortfolioRange) =>
   saveSettings({ selectedTimeRange });
 export const setDeveloperMode = (developerMode: boolean) => saveSettings({ developerMode });
+export const setDiscreetMode = (discreetMode: boolean) => saveSettings({ discreetMode });
 export const setSentryLogs = (sentryLogs: boolean) => saveSettings({ sentryLogs });
 export const setShareAnalytics = (shareAnalytics: boolean) => saveSettings({ shareAnalytics });
 export const setMarketIndicator = (marketIndicator: *) => saveSettings({ marketIndicator });

--- a/src/renderer/components/FormattedVal.js
+++ b/src/renderer/components/FormattedVal.js
@@ -9,7 +9,11 @@ import { createStructuredSelector } from "reselect";
 import type { Unit } from "@ledgerhq/live-common/lib/types";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/lib/currencies";
 import { DISABLE_TICKER_ANIMATION } from "~/config/constants";
-import { marketIndicatorSelector, localeSelector } from "~/renderer/reducers/settings";
+import {
+  marketIndicatorSelector,
+  localeSelector,
+  discreetModeSelector,
+} from "~/renderer/reducers/settings";
 import { getMarketColor } from "~/renderer/styles/helpers";
 import Box from "~/renderer/components/Box";
 import FlipTicker from "~/renderer/components/FlipTicker";
@@ -59,11 +63,13 @@ type OwnProps = {
 
 const mapStateToProps = createStructuredSelector({
   marketIndicator: marketIndicatorSelector,
+  discreet: discreetModeSelector,
   locale: localeSelector,
 });
 
 type Props = OwnProps & {
   marketIndicator: string,
+  discreet: boolean,
   locale: string,
 };
 
@@ -83,6 +89,7 @@ function FormattedVal(props: Props) {
     subMagnitude,
     prefix,
     suffix,
+    discreet,
     ...p
   } = props;
   let { val } = props;
@@ -112,6 +119,7 @@ function FormattedVal(props: Props) {
       showCode,
       locale,
       subMagnitude,
+      discreet,
     });
   }
 

--- a/src/renderer/components/TopBar/index.js
+++ b/src/renderer/components/TopBar/index.js
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import { lock } from "~/renderer/actions/application";
 import { openModal } from "~/renderer/actions/modals";
 
-import { hasPasswordSelector } from "~/renderer/reducers/settings";
+import { discreetModeSelector, hasPasswordSelector } from "~/renderer/reducers/settings";
 import { hasAccountsSelector } from "~/renderer/reducers/accounts";
 
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -21,11 +21,14 @@ import Tooltip from "~/renderer/components/Tooltip";
 import Breadcrumb from "~/renderer/components/Breadcrumb";
 
 import IconLock from "~/renderer/icons/Lock";
+import IconEye from "~/renderer/icons/Eye";
+import IconEyeOff from "~/renderer/icons/EyeOff";
 import IconSettings from "~/renderer/icons/Settings";
 
 // TODO: ActivityIndicator
 import ActivityIndicator from "./ActivityIndicator";
 import ItemContainer from "./ItemContainer";
+import { setDiscreetMode } from "~/renderer/actions/settings";
 
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
   px: 6,
@@ -65,9 +68,13 @@ const TopBar = () => {
   const location = useLocation();
   const hasPassword = useSelector(hasPasswordSelector);
   const hasAccounts = useSelector(hasAccountsSelector);
+  const discreetMode = useSelector(discreetModeSelector);
 
   const handleLock = useCallback(() => dispatch(lock()), [dispatch]);
-
+  const handleDiscreet = useCallback(() => dispatch(setDiscreetMode(!discreetMode)), [
+    discreetMode,
+    dispatch,
+  ]);
   const navigateToSettings = useCallback(() => {
     const url = "/settings";
 
@@ -101,6 +108,14 @@ const TopBar = () => {
             <Tooltip content={t("settings.title")} placement="bottom">
               <ItemContainer data-e2e="setting_button" isInteractive onClick={navigateToSettings}>
                 <IconSettings size={16} />
+              </ItemContainer>
+            </Tooltip>
+            <Box justifyContent="center">
+              <Bar />
+            </Box>
+            <Tooltip content={t("settings.discreet")} placement="bottom">
+              <ItemContainer data-e2e="discreet_button" isInteractive onClick={handleDiscreet}>
+                {discreetMode ? <IconEyeOff size={16} /> : <IconEye size={16} />}
               </ItemContainer>
             </Tooltip>
             {hasPassword && (

--- a/src/renderer/i18n/en/app.json
+++ b/src/renderer/i18n/en/app.json
@@ -748,6 +748,7 @@
   },
   "settings": {
     "title": "Settings",
+    "discreet": "Toggle discreet mode",
     "tabs": {
       "display": "General",
       "cryptoAssets": "Crypto assets",

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -91,6 +91,7 @@ export type SettingsState = {
   showAccountsHelperBanner: boolean,
   hideEmptyTokenAccounts: boolean,
   sidebarCollapsed: boolean,
+  discreetMode: boolean,
 };
 
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {
@@ -126,6 +127,7 @@ const INITIAL_STATE: SettingsState = {
   showAccountsHelperBanner: true,
   hideEmptyTokenAccounts: getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
   sidebarCollapsed: false,
+  discreetMode: false,
 };
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`;
@@ -204,6 +206,8 @@ export const storeSelector = (state: State): SettingsState => state.settings;
 export const settingsExportSelector = storeSelector;
 
 export const hasPasswordSelector = (state: State): boolean => state.settings.hasPassword === true;
+
+export const discreetModeSelector = (state: State): boolean => state.settings.discreetMode === true;
 
 export const getCounterValueCode = (state: State) => state.settings.counterValue;
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/72521790-7045f100-385c-11ea-90c6-8bf231270aae.png)

Brings the discreet mode feature back from the dead, I think it's a good idea we merge quickly since we are iterating fast in lldv2 and then we tackle minor things like the probable icon changes or possible bugs we might encounter. This pr is essentially bringing back the work from @jorge-cob on https://github.com/LedgerHQ/ledger-live-desktop/pull/2157 but using the new config available from live-common at [`formatCurrencyUnit`](https://github.com/LedgerHQ/ledger-live-common/blob/44aae4c8d7148103576c65192d403f8af83ac918/src/currencies/formatCurrencyUnit.js#L28) 

### Type

Feature
