### PR TITLE
Enable option to automatically use OS Theme for dark/light mode

### DIFF
--- a/src/renderer/actions/application.js
+++ b/src/renderer/actions/application.js
@@ -3,3 +3,4 @@ import { createAction } from "redux-actions";
 
 export const unlock = createAction("APPLICATION_SET_DATA", () => ({ isLocked: false }));
 export const lock = createAction("APPLICATION_SET_DATA", () => ({ isLocked: true }));
+export const setOSDarkMode = createAction("APPLICATION_SET_DATA", osDarkMode => ({ osDarkMode }));

--- a/src/renderer/actions/general.js
+++ b/src/renderer/actions/general.js
@@ -101,5 +101,5 @@ export const refreshAccountsOrdering = () => (dispatch: *, getState: *) => {
 export const themeSelector: OutputSelector<State, void, string> = createSelector(
   osDarkModeSelector,
   userThemeSelector,
-  (osDark, theme) => (theme !== "system" ? theme || "light" : osDark ? "dark" : "light"),
+  (osDark, theme) => theme || (osDark ? "dark" : "light"),
 );

--- a/src/renderer/actions/general.js
+++ b/src/renderer/actions/general.js
@@ -17,9 +17,11 @@ import {
   exchangeSettingsForPairSelector,
   getOrderAccounts,
   counterValueCurrencySelector,
+  userThemeSelector,
 } from "./../reducers/settings";
 import { accountsSelector, activeAccountsSelector } from "./../reducers/accounts";
 import type { State } from "./../reducers";
+import { osDarkModeSelector } from "~/renderer/reducers/application";
 
 export const calculateCountervalueSelector = (state: State) => {
   const counterValueCurrency = counterValueCurrencySelector(state);
@@ -95,3 +97,9 @@ export const refreshAccountsOrdering = () => (dispatch: *, getState: *) => {
     payload: nestedSortAccountsSelector(getState()),
   });
 };
+
+export const themeSelector: OutputSelector<State, void, string> = createSelector(
+  osDarkModeSelector,
+  userThemeSelector,
+  (osDark, theme) => (theme !== "system" ? theme || "light" : osDark ? "dark" : "light"),
+);

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -30,7 +30,7 @@ import createStore from "~/renderer/createStore";
 import events from "~/renderer/events";
 import { fetchAccounts } from "~/renderer/actions/accounts";
 import { fetchSettings } from "~/renderer/actions/settings";
-import { lock } from "~/renderer/actions/application";
+import { lock, setOSDarkMode } from "~/renderer/actions/application";
 
 import {
   languageSelector,
@@ -102,6 +102,10 @@ async function init() {
 
   if (isMainWindow) {
     webFrame.setVisualZoomLevelLimits(1, 1);
+
+    const matcher = window.matchMedia("(prefers-color-scheme: dark)");
+    const updateOSTheme = () => store.dispatch(setOSDarkMode(matcher.matches));
+    matcher.addListener(updateOSTheme);
 
     events({ store });
 

--- a/src/renderer/reducers/application.js
+++ b/src/renderer/reducers/application.js
@@ -4,9 +4,12 @@ import { handleActions } from "redux-actions";
 
 export type ApplicationState = {
   isLocked?: boolean,
+  osDarkMode?: boolean,
 };
 
-const state: ApplicationState = {};
+const state: ApplicationState = {
+  osDarkMode: window.matchMedia("(prefers-color-scheme: dark)").matches,
+};
 
 const handlers = {
   APPLICATION_SET_DATA: (state, { payload }: { payload: ApplicationState }) => ({
@@ -20,6 +23,8 @@ const handlers = {
 // Selectors
 
 export const isLocked = (state: Object) => state.application.isLocked === true;
+
+export const osDarkModeSelector = (state: Object) => state.application.osDarkMode;
 
 // Exporting reducer
 

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -228,7 +228,7 @@ export const developerModeSelector = (state: State): boolean => state.settings.d
 
 export const lastUsedVersionSelector = (state: State): string => state.settings.lastUsedVersion;
 
-export const themeSelector = (state: State): ?string => state.settings.theme;
+export const userThemeSelector = (state: State): ?string => state.settings.theme;
 
 export const langAndRegionSelector = (
   state: State,

--- a/src/renderer/screens/onboarding/steps/ThemeSelector.js
+++ b/src/renderer/screens/onboarding/steps/ThemeSelector.js
@@ -6,7 +6,7 @@ import { Trans } from "react-i18next";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import palettes from "~/renderer/styles/palettes";
-import { themeSelector } from "~/renderer/reducers/settings";
+import { themeSelector } from "~/renderer/actions/general";
 import { setTheme } from "~/renderer/actions/settings";
 import Text from "~/renderer/components/Text";
 

--- a/src/renderer/screens/settings/sections/General/ThemeSelect.js
+++ b/src/renderer/screens/settings/sections/General/ThemeSelect.js
@@ -4,11 +4,12 @@ import React, { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { setTheme } from "~/renderer/actions/settings";
-import { themeSelector } from "~/renderer/reducers/settings";
+import { userThemeSelector } from "~/renderer/reducers/settings";
 import Select from "~/renderer/components/Select";
 import Track from "~/renderer/analytics/Track";
 
 const themeLabels = {
+  system: "theme.system",
   light: "theme.light",
   dusk: "theme.dusk",
   dark: "theme.dark",
@@ -16,7 +17,7 @@ const themeLabels = {
 
 const ThemeSelect = () => {
   const dispatch = useDispatch();
-  const theme = useSelector(themeSelector);
+  const theme = useSelector(userThemeSelector);
   const { t } = useTranslation();
 
   const handleChangeTheme = useCallback(

--- a/src/renderer/screens/settings/sections/General/ThemeSelect.js
+++ b/src/renderer/screens/settings/sections/General/ThemeSelect.js
@@ -9,7 +9,6 @@ import Select from "~/renderer/components/Select";
 import Track from "~/renderer/analytics/Track";
 
 const themeLabels = {
-  system: "theme.system",
   light: "theme.light",
   dusk: "theme.dusk",
   dark: "theme.dark",
@@ -29,10 +28,12 @@ const ThemeSelect = () => {
 
   const options = useMemo(
     () =>
-      Object.keys(themeLabels).map(key => ({
-        value: key,
-        label: t(themeLabels[key]),
-      })),
+      [{ value: null, label: t("theme.system") }].concat(
+        Object.keys(themeLabels).map(key => ({
+          value: key,
+          label: t(themeLabels[key]),
+        })),
+      ),
     [t],
   );
 

--- a/src/renderer/styles/StyleProvider.js
+++ b/src/renderer/styles/StyleProvider.js
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from "~/renderer/styles/global";
 import type { StyledComponent } from "styled-components";
-import { themeSelector } from "~/renderer/reducers/settings";
+import { themeSelector } from "~/renderer/actions/general";
 import defaultTheme from "./theme";
 import palettes from "./palettes";
 import type { Theme } from "./theme";


### PR DESCRIPTION
The initial approach using the method described in the electron documentation where we listen to the `AppleInterfaceThemeChangedNotification` event and relying on `nativeTheme.shouldUseDarkColors` was returning inconsistent results where sometimes it would be true and sometimes, especially after a relaunch, the `shouldUseDarkColors` would flip on me. Following a suggestion from @gre and relying on the preferences provided by the browser window itself.

![Jan-20-2020 19-26-33](https://user-images.githubusercontent.com/4631227/72749601-cc8d7580-3bba-11ea-9308-d919658e99a0.gif)

All the content relying on the theme is unaffected and we only need a wrapper around the user theme for the settings. The rest seems to work pretty well. The behavior is that if we have set a theme manually instead of setting the "system default", it will use that otherwise it will rely on the OS preference.

I have *not* done anything for the onboarding though.