### PR TITLE
prevent huge logs during syncs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ledgerhq/hw-transport-http": "^5.6.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.6.0",
     "@ledgerhq/ledger-core": "^5.3.0",
-    "@ledgerhq/live-common": "^11.1.1",
+    "@ledgerhq/live-common": "^11.1.3",
     "@ledgerhq/logs": "^5.6.0",
     "@tippy.js/react": "^3.1.1",
     "animated": "^0.2.2",

--- a/src/live-common-setup.js
+++ b/src/live-common-setup.js
@@ -15,7 +15,10 @@ setEnv("DEVICE_CANCEL_APDU_FLUSH_MECHANISM", false);
 
 setWebSocketImplementation(WebSocket);
 setNetwork(network);
-listenLogs(({ id, date, ...log }) => logger.debug(log));
+listenLogs(({ id, date, ...log }) => {
+  if (log.type === "hid-frame") return;
+  logger.debug(log);
+});
 websocketLogs.subscribe(({ type, message, ...rest }) => {
   const obj = rest;
   if (message) obj.msg = message;

--- a/src/logger/logger-transport-main.js
+++ b/src/logger/logger-transport-main.js
@@ -3,7 +3,7 @@ import Transport from "winston-transport";
 export default class MainTransport extends Transport {
   logs = [];
   capacity = 3000;
-  blacklist = ["hid-frame"];
+  blacklist = [];
 
   log(info, callback) {
     setImmediate(() => {

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -116,32 +116,80 @@ const logAnalytics = !process.env.NO_DEBUG_ANALYTICS;
 const logApdu = !process.env.NO_DEBUG_DEVICE;
 const logCountervalues = !process.env.NO_DEBUG_COUNTERVALUES;
 
-const blacklistTooVerboseCommandInput = [
-  "CurrencyScanAccountsOnDevice",
-  "AccountStartSync",
-  "AccountPrepareTransaction",
-  "AccountGetTransactionStatus",
-  "AccountSignAndBroadcast",
-];
-const blacklistTooVerboseCommandResponse = ["AccountStartSync", "CurrencyScanAccountsOnDevice"];
+function summarizeAccount({
+  type,
+  balance,
+  id,
+  index,
+  freshAddress,
+  freshAddressPath,
+  name,
+  operations,
+  pendingOperations,
+  subAccounts,
+}: Object) {
+  const o: Object = {
+    type,
+    balance,
+    id,
+    name,
+    index,
+    freshAddress,
+    freshAddressPath,
+  };
+  if (operations && typeof operations === "object" && Array.isArray(operations)) {
+    o.opsL = operations.length;
+  }
+  if (
+    pendingOperations &&
+    typeof pendingOperations === "object" &&
+    Array.isArray(pendingOperations)
+  ) {
+    o.pendingOpsL = pendingOperations.length;
+  }
+  if (subAccounts && typeof subAccounts === "object" && Array.isArray(subAccounts)) {
+    o.subA = subAccounts.map(o => summarizeAccount(o));
+  }
+  return o;
+}
+
+// minize objects that gets logged to keep the essential
+export const summarize = (obj: mixed, key?: string): mixed => {
+  switch (typeof obj) {
+    case "object": {
+      if (!obj) return obj;
+      if (key === "appByName") return "(removed)";
+      if (key === "firmware") return "(removed)";
+      if (Array.isArray(obj)) {
+        return obj.map(o => summarize(o));
+      }
+      if (
+        obj.type === "Account" ||
+        // AccountRaw
+        ("seedIdentifier" in obj && "freshAddressPath" in obj && "operations" in obj)
+      ) {
+        return summarizeAccount(obj);
+      }
+      const copy = {};
+      for (const k in obj) {
+        copy[k] = summarize(obj[k], k);
+      }
+      return copy;
+    }
+    default:
+      return obj;
+  }
+};
 
 export default {
   onCmd: (type: string, id: string, spentTime: number, data?: any) => {
     if (logCmds) {
       switch (type) {
         case "cmd.START":
-          logger.log(
-            "info",
-            `CMD ${id}.send()`,
-            blacklistTooVerboseCommandInput.includes(id) ? { type } : { type, data },
-          );
+          logger.log("info", `CMD ${id}.send()`, summarize({ type, data }));
           break;
         case "cmd.NEXT":
-          logger.log(
-            "info",
-            `● CMD ${id}`,
-            blacklistTooVerboseCommandResponse.includes(id) ? { type } : { type, data },
-          );
+          logger.log("info", `● CMD ${id}`, summarize({ type, data }));
           break;
         case "cmd.COMPLETE":
           logger.log("info", `✔ CMD ${id} finished in ${spentTime.toFixed(0)}ms`, { type });
@@ -151,7 +199,7 @@ export default {
           });
           break;
         case "cmd.ERROR":
-          logger.log("warn", `✖ CMD ${id} error`, { type, data });
+          logger.log("warn", `✖ CMD ${id} error`, summarize({ type, data }));
           captureBreadcrumb({
             category: "command",
             message: `✖ ${id}`,

--- a/src/renderer/components/ManagerConnect/logic.js
+++ b/src/renderer/components/ManagerConnect/logic.js
@@ -1,8 +1,7 @@
 // @flow
 import { ReplaySubject, concat, of, empty, interval } from "rxjs";
-import { scan, debounce, debounceTime, catchError, switchMap, tap } from "rxjs/operators";
+import { scan, debounce, debounceTime, catchError, switchMap } from "rxjs/operators";
 import { useEffect, useCallback, useState } from "react";
-import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/live-common/lib/types/manager";
 import type { ListAppsResult } from "@ledgerhq/live-common/lib/apps/types";
 import manager from "@ledgerhq/live-common/lib/manager";
@@ -161,7 +160,6 @@ export const useManagerConnect = (device: ?Device): [State, Cbs] => {
         debounceTime(1000),
         // each time there is a device change, we pipe to the command
         switchMap(connectManager),
-        tap(e => log("manager-connect-event", e.type, e)),
         // tap(e => console.log("connectManager event", e)),
         // we gather all events with a reducer into the UI state
         scan(reducer, getInitialState()),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,10 +1215,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.6.0.tgz#878851b961a34c1bda3618b3568b4e8faed532bd"
   integrity sha512-zdEYEsmfhFHv7f89srh7qI5XP0DIkV9xkONsE8dVHhqpoFx732yKozpVDFUp4zhaCCT/xNL5wbCDxM9edk6Uig==
 
-"@ledgerhq/hw-app-btc@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-5.6.0.tgz#cd72375303695936eaee2d3b1f5a60508c0aebcc"
-  integrity sha512-qFh1LQGtH9zAwtVW1LujUTCqov6wyX+m+Tt/2zdwiLxXUUXhOTqhGxReVe8QKnzoiH9wA+6XvzsB+TBGYahJwg==
+"@ledgerhq/hw-app-btc@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-5.6.1.tgz#86ccb3d44ae7c476f43b291514555cd71cfb4163"
+  integrity sha512-T6nQGYTFyMABlnwuP0QuLFh4Prw07Mn+ExMi9tjWXNImMQ093G1jt8GUKxdrXGuJ2rjHYCxi7UsgT5jYd7hiKA==
   dependencies:
     "@ledgerhq/hw-transport" "^5.6.0"
     bip32-path "^0.4.2"
@@ -1302,15 +1302,15 @@
     bindings "1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^11.1.1":
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.1.1.tgz#049e68082ca87658e909860aed56fd28c28e90d0"
-  integrity sha512-peUBQzQzem/mRbtKliRQP2MxwSHNkJQEKjCfMSjbwN6SuK8bjYcm47SrQ1BiKBA8NsdIYNOx6s9z7vKM4vnWVw==
+"@ledgerhq/live-common@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.1.3.tgz#0ad36eb5dfd795ea8ff678c85389a8264504b12a"
+  integrity sha512-5peWskSIyngt5Ai/vp3eKG6hi6eqhAK5cMJ478VrF/TpNSPah0TE5/5D23Gbe3jQAedPvouC4aUACnY09iIHqw==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.6.0"
     "@ledgerhq/errors" "5.6.0"
-    "@ledgerhq/hw-app-btc" "5.6.0"
+    "@ledgerhq/hw-app-btc" "5.6.1"
     "@ledgerhq/hw-app-eth" "5.6.0"
     "@ledgerhq/hw-app-xrp" "5.6.0"
     "@ledgerhq/hw-transport" "5.6.0"


### PR DESCRIPTION
this will minimize the logs at the logger time so we have both more readable trace, but also there will be smaller exchanges between process (for logs) and for the exported logs.
typically we replace the Account objects into minimized version (with just the minimal infos)