### PR TITLE
LL-2139 Fix top account navigation on breadcrumbs

### DIFF
--- a/src/renderer/components/Breadcrumb/AccountCrumb.js
+++ b/src/renderer/components/Breadcrumb/AccountCrumb.js
@@ -95,7 +95,7 @@ const AccountCrumb = () => {
 
   const openActiveAccount = useCallback(
     (e: SyntheticEvent<HTMLButtonElement>) => {
-      e.preventDefault();
+      e.stopPropagation();
       if (parentId) {
         if (id) {
           history.push(`/account/${parentId}/${id}`);


### PR DESCRIPTION
It no longer should open the dropdown menu when clicking on the top level account.

### Type

Bug fix
### Context

https://ledgerhq.atlassian.net/browse/LL-2139