### PR TITLE
<ErrorDisplay /> + Troubleshooting rework

### DIFF
--- a/src/renderer/components/Button.js
+++ b/src/renderer/components/Button.js
@@ -309,6 +309,8 @@ export type Props = {
   danger?: boolean,
   lighterDanger?: boolean,
   disabled?: boolean,
+  outline?: boolean,
+  outlineGrey?: boolean,
   onClick?: Function,
   small?: boolean,
   isLoading?: boolean,

--- a/src/renderer/components/ConnectTroubleshooting.js
+++ b/src/renderer/components/ConnectTroubleshooting.js
@@ -1,15 +1,25 @@
 // @flow
 import React, { useState, useEffect } from "react";
 import { Trans } from "react-i18next";
+import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
-import ConnectTroubleshootingHelpButton from "~/renderer/components/ConnectTroubleshootingHelpButton";
+import ConnectTroubleshootingHelpLink from "~/renderer/components/ConnectTroubleshootingHelpLink";
+import IconHelp from "~/renderer/icons/Help";
 import RepairDeviceButton from "~/renderer/components/RepairDeviceButton";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 type Props = {
   appearsAfterDelay?: number,
   onRepair?: boolean => void,
 };
+
+const Wrapper: ThemedComponent<{}> = styled(Box).attrs({
+  horizontal: true,
+  alignItems: "center",
+  backgroundColor: "palette.text.shade10",
+  borderRadius: 4,
+})``;
 
 const ConnectTroubleshooting = ({ appearsAfterDelay = 25000, onRepair }: Props) => {
   const [visible, setVisible] = useState(false);
@@ -19,17 +29,22 @@ const ConnectTroubleshooting = ({ appearsAfterDelay = 25000, onRepair }: Props) 
   }, [appearsAfterDelay]);
 
   return visible ? (
-    <Box p={4} alignItems="center">
-      <Box p={2}>
-        <Text ff="Inter|SemiBold" fontSize={4}>
+    <Wrapper p={2} horizontal alignItems="center">
+      <Box p={2} horizontal justifyContent="center">
+        <Box marginRight="8px" justifyContent="center">
+          <IconHelp size={16} />
+        </Box>
+        <Text ff="Inter|Regular" fontSize={4}>
           <Trans i18nKey="connectTroubleshooting.desc" />
         </Text>
       </Box>
       <Box horizontal>
-        <ConnectTroubleshootingHelpButton />
+        <Box marginRight={100} justifyContent="center">
+          <ConnectTroubleshootingHelpLink />
+        </Box>
         <RepairDeviceButton onRepair={onRepair} />
       </Box>
-    </Box>
+    </Wrapper>
   ) : null;
 };
 

--- a/src/renderer/components/ConnectTroubleshootingHelpLink.js
+++ b/src/renderer/components/ConnectTroubleshootingHelpLink.js
@@ -1,0 +1,32 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { urls } from "~/config/urls";
+import { openURL } from "~/renderer/linking";
+import { colors } from "~/renderer/styles/theme";
+import Button from "~/renderer/components/Button";
+import Box from "~/renderer/components/Box";
+import IconHelp from "~/renderer/icons/Help";
+import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
+
+const ConnectTroubleshootingHelpButton = () => {
+  const { t } = useTranslation();
+
+  return (
+    <LinkWithExternalIcon
+      onClick={() => openURL(urls.troubleshootingUSB)}
+      style={{ margin: "0 10px" }}
+    >
+      <Box color={colors.wallet} horizontal alignItems="center">
+        {t("common.help")}
+      </Box>
+    </LinkWithExternalIcon>
+  );
+};
+
+const ConnectTroubleshootingHelpButtonOut: React$ComponentType<{}> = React.memo(
+  ConnectTroubleshootingHelpButton,
+);
+
+export default ConnectTroubleshootingHelpButtonOut;

--- a/src/renderer/components/ConnectTroubleshootingHelpLink.js
+++ b/src/renderer/components/ConnectTroubleshootingHelpLink.js
@@ -5,9 +5,7 @@ import { useTranslation } from "react-i18next";
 import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
 import { colors } from "~/renderer/styles/theme";
-import Button from "~/renderer/components/Button";
 import Box from "~/renderer/components/Box";
-import IconHelp from "~/renderer/icons/Help";
 import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
 
 const ConnectTroubleshootingHelpButton = () => {

--- a/src/renderer/components/ErrorDisplay.js
+++ b/src/renderer/components/ErrorDisplay.js
@@ -1,0 +1,88 @@
+// @flow
+
+import React from "react";
+import styled from "styled-components";
+import { useTranslation } from "react-i18next";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import Button from "~/renderer/components/Button";
+import ExportLogsButton from "~/renderer/components/ExportLogsButton";
+import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
+import Box from "~/renderer/components/Box";
+import Text from "~/renderer/components/Text";
+
+const Wrapper: ThemedComponent<{}> = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Logo = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: ${p => p.theme.colors.alertRed};
+  margin-bottom: 20px;
+`;
+
+const Title = styled(Text).attrs({
+  ff: "Inter|SemiBold",
+  color: "palette.text.shade100",
+  textAlign: "center",
+  fontSize: 6,
+})`
+  margin-bottom: 10px;
+`;
+
+const Description = styled(Text).attrs({
+  ff: "Inter|Regular",
+  color: "palette.text.shade60",
+  textAlign: "center",
+  fontSize: 4,
+})``;
+
+const ButtonContainer = styled(Box).attrs(p => ({
+  mt: 25,
+  horizontal: true,
+}))``;
+
+type Props = {
+  error: Error,
+  onRetry?: () => void,
+  withExportLogs?: boolean,
+};
+
+const ErrorDisplay = ({ error, onRetry, withExportLogs }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <Wrapper>
+      <Logo>
+        <ExclamationCircleThin size={44} />
+      </Logo>
+      <Title>
+        <TranslatedError error={error} />
+      </Title>
+      <Description>
+        <TranslatedError error={error} field="description" />
+      </Description>
+      <ButtonContainer>
+        {withExportLogs ? (
+          <ExportLogsButton
+            title={t("settings.exportLogs.title")}
+            small={false}
+            primary={false}
+            outlineGrey
+          />
+        ) : null}
+        <Button primary ml={withExportLogs ? 4 : 0} onClick={onRetry}>
+          {t("common.retry")}
+        </Button>
+      </ButtonContainer>
+    </Wrapper>
+  );
+};
+
+export default ErrorDisplay;

--- a/src/renderer/components/ExportLogsButton.js
+++ b/src/renderer/components/ExportLogsButton.js
@@ -45,6 +45,7 @@ type Props = {|
   small?: boolean,
   hookToShortcut?: boolean,
   title?: string,
+  withoutAppData?: boolean,
 |};
 
 const ExportLogsBtn = ({ hookToShortcut, primary = true, small = true, title, ...rest }: Props) => {

--- a/src/renderer/components/ExportLogsButton.js
+++ b/src/renderer/components/ExportLogsButton.js
@@ -3,7 +3,7 @@ import fs from "fs";
 import moment from "moment";
 import { ipcRenderer, webFrame, remote } from "electron";
 import React, { useState, useCallback } from "react";
-import { Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { getAllEnvs } from "@ledgerhq/live-common/lib/env";
 import KeyHandler from "react-key-handler";
 import logger from "~/logger";
@@ -25,11 +25,30 @@ const writeToFile = (file, data) =>
     });
   });
 
-type Props = {
-  hookToShortcut?: boolean,
-};
+type RestProps = {|
+  icon?: boolean,
+  inverted?: boolean, // only used with primary for now
+  lighterPrimary?: boolean,
+  danger?: boolean,
+  lighterDanger?: boolean,
+  disabled?: boolean,
+  isLoading?: boolean,
+  event?: string,
+  eventProperties?: Object,
+  outline?: boolean,
+  outlineGrey?: boolean,
+|};
 
-const ExportLogsBtn = ({ hookToShortcut }: Props) => {
+type Props = {|
+  ...RestProps,
+  primary?: boolean,
+  small?: boolean,
+  hookToShortcut?: boolean,
+  title?: string,
+|};
+
+const ExportLogsBtn = ({ hookToShortcut, primary = true, small = true, title, ...rest }: Props) => {
+  const { t } = useTranslation();
   const [exporting, setExporting] = useState(false);
 
   const exportLogs = useCallback(async () => {
@@ -88,11 +107,13 @@ const ExportLogsBtn = ({ hookToShortcut }: Props) => {
     [handleExportLogs],
   );
 
+  const text = title || t("settings.exportLogs.btn");
+
   return hookToShortcut ? (
     <KeyHandler keyValue="e" onKeyHandle={onKeyHandle} />
   ) : (
-    <Button small primary event="ExportLogs" onClick={handleExportLogs}>
-      <Trans i18nKey="settings.exportLogs.btn" />
+    <Button small={small} primary={primary} event="ExportLogs" onClick={handleExportLogs} {...rest}>
+      {text}
     </Button>
   );
 };

--- a/src/renderer/components/ManagerConnect/index.js
+++ b/src/renderer/components/ManagerConnect/index.js
@@ -12,7 +12,6 @@ import { preferredDeviceModelSelector } from "~/renderer/reducers/settings";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import type { Device } from "~/renderer/reducers/devices";
 import Animation from "~/renderer/animations";
-import TranslatedError from "~/renderer/components/TranslatedError";
 import BigSpinner from "~/renderer/components/BigSpinner";
 import AutoRepair from "~/renderer/components/AutoRepair";
 import Button from "~/renderer/components/Button";
@@ -20,6 +19,7 @@ import ConnectTroubleshooting from "~/renderer/components/ConnectTroubleshooting
 import Text from "~/renderer/components/Text";
 import useTheme from "~/renderer/hooks/useTheme";
 import { useManagerConnect } from "./logic";
+import ErrorDisplay from "../ErrorDisplay";
 
 const animations: { [k: DeviceModelId]: * } = {
   nanoX: {
@@ -205,16 +205,7 @@ const ManagerConnect = ({
   }
 
   if (!isLoading && error) {
-    return (
-      <Wrapper>
-        <Title>
-          <TranslatedError error={error} />
-        </Title>
-        <Button mt={2} primary onClick={onRetry}>
-          <Trans i18nKey="common.retry" />
-        </Button>
-      </Wrapper>
-    );
+    return <ErrorDisplay error={error} onRetry={onRetry} withExportLogs />;
   }
 
   if ((!isLoading && !device) || unresponsive) {

--- a/src/renderer/components/ManagerConnect/index.js
+++ b/src/renderer/components/ManagerConnect/index.js
@@ -131,6 +131,14 @@ const Header = styled.div`
 
 const Footer = styled.div`
   min-height: ${p => p.edges || 0}px;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin-bottom: 40px;
+`;
+
+const TroobleshootingWrapper = styled.div`
+  margin-top: auto;
 `;
 
 const ManagerConnect = ({
@@ -231,7 +239,11 @@ const ManagerConnect = ({
               }
             />
           </Title>
-          {!device ? <ConnectTroubleshooting onRepair={onRepairModal} /> : null}
+          {!device ? (
+            <TroobleshootingWrapper>
+              <ConnectTroubleshooting onRepair={onRepairModal} />
+            </TroobleshootingWrapper>
+          ) : null}
         </Footer>
       </Wrapper>
     );

--- a/src/renderer/components/RenderError.js
+++ b/src/renderer/components/RenderError.js
@@ -135,6 +135,7 @@ class RenderError extends PureComponent<
           <Button small primary onClick={this.handleRestart}>
             {t("crash.restart")}
           </Button>
+          {/* FIXME: What is this ? It was not used in ExportLogsButton */}
           <ExportLogsButton withoutAppData={withoutAppData} />
           <ExternalLinkButton small primary label={t("crash.support")} url={urls.contactSupport} />
           <Button small primary onClick={this.github}>


### PR DESCRIPTION
This PR adds a new generic `<ErrorDisplay />` component, as well as a rework of the `<ConnectTroobleshooting />` component (present in ManagerConnect)

### Type

Feature + UI Polish

### Context

@gre 

### Parts of the app affected / Test plan

Right now only `<ManagerConnect />` is using `<ErrorDisplay />`

#### Error Screen

![image](https://user-images.githubusercontent.com/671786/73082328-93f6e000-3ec9-11ea-8983-9124c5527d0a.png)


#### Troubleshooting Screen

![image](https://user-images.githubusercontent.com/671786/73082273-70cc3080-3ec9-11ea-9e9e-2cea2d1df6ad.png)
