### PR TITLE
Better internal->main logs and only enable debug on main/renderer

### DIFF
--- a/src/logger/logger-transport-internal.js
+++ b/src/logger/logger-transport-internal.js
@@ -1,17 +1,12 @@
 import Transport from "winston-transport";
 
 export default class InternalTransport extends Transport {
-  log(info, callback) {
+  log(log, callback) {
     setImmediate(() => {
-      this.emit("logged", info);
+      this.emit("logged", log);
     });
 
-    try {
-      process.send({
-        type: "log",
-        log: info,
-      });
-    } catch (e) {}
+    console.log(JSON.stringify({ type: "log", log }));
 
     callback();
   }

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -17,7 +17,17 @@ const pinfo = format(info => {
 
 const transports = [];
 
-if (process.env.NODE_ENV !== "production" || process.env.DEV_TOOLS) {
+const logger = winston.createLogger({
+  level: "debug",
+  format: combine(pinfo(), timestamp(), json()),
+  transports,
+});
+
+const add = (transport: *) => {
+  logger.add(transport);
+};
+
+export function enableDebugLogger() {
   let consoleT;
   if (typeof window === "undefined") {
     // on Node we want a concise logger
@@ -59,18 +69,8 @@ if (process.env.NODE_ENV !== "production" || process.env.DEV_TOOLS) {
     }
     consoleT = new CustomConsole();
   }
-  transports.push(consoleT);
+  add(consoleT);
 }
-
-const logger = winston.createLogger({
-  level: "debug",
-  format: combine(pinfo(), timestamp(), json()),
-  transports,
-});
-
-const add = (transport: *) => {
-  logger.add(transport);
-};
 
 const captureBreadcrumb = (breadcrumb: any) => {
   // FIXME

--- a/src/main/internal-lifecycle.js
+++ b/src/main/internal-lifecycle.js
@@ -64,6 +64,7 @@ const spawnCoreProcess = () => {
 
   cluster.setupMaster({
     exec: `${__dirname}/main.bundle.js`,
+    execArgv: (process.env.LEDGER_INTERNAL_ARGS || "").split(/[ ]+/).filter(Boolean),
     silent: true,
   });
 
@@ -82,11 +83,13 @@ const spawnCoreProcess = () => {
             return;
           }
         } catch (e) {}
-        logger.debug("internal: " + msg);
+        logger.debug("I: " + msg);
       }),
   );
   worker.process.stderr.on("data", data => {
-    logger.error("internal error: " + String(data).trim());
+    const msg = String(data).trim();
+    if (__DEV__) console.error("I.e: " + msg);
+    logger.error("I.e: " + String(data).trim());
   });
 
   worker.on("message", handleGlobalInternalMessage);

--- a/src/main/setup.js
+++ b/src/main/setup.js
@@ -2,13 +2,17 @@
 
 import "../env";
 import { ipcMain } from "electron";
-import logger from "../logger";
+import logger, { enableDebugLogger } from "../logger";
 import LoggerTransport from "../logger/logger-transport-main";
 import contextMenu from "electron-context-menu";
 import updater from "./updater";
 
 const loggerTransport = new LoggerTransport();
 logger.add(loggerTransport);
+
+if (process.env.DEV_TOOLS) {
+  enableDebugLogger();
+}
 
 ipcMain.on("log", (e, { log }) => {
   logger.onLog(log);

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -16,7 +16,7 @@ import "~/renderer/live-common-setup";
 import "~/renderer/experimental";
 import "~/renderer/i18n/init";
 
-import logger from "~/logger";
+import logger, { enableDebugLogger } from "~/logger";
 import LoggerTransport from "~/logger/logger-transport-renderer";
 import { DEBUG_TICK_REDUX } from "~/config/constants";
 import { enableGlobalTab, disableGlobalTab, isGlobalTabEnabled } from "~/config/global-tab";
@@ -41,6 +41,10 @@ import ReactRoot from "~/renderer/ReactRoot";
 import AppError from "~/renderer/AppError";
 
 logger.add(new LoggerTransport());
+
+if (process.env.NODE_ENV !== "production" || process.env.DEV_TOOLS) {
+  enableDebugLogger();
+}
 
 const rootNode = document.getElementById("react-root");
 

--- a/tools/utils/Electron.js
+++ b/tools/utils/Electron.js
@@ -13,6 +13,7 @@ class Electron {
     if (!this.instance) {
       this.instance = execa(this.electronPath, [this.bundlePath]);
       this.instance.stdout.pipe(process.stdout);
+      this.instance.stderr.pipe(process.stderr);
     }
   }
 


### PR DESCRIPTION
using stdout/stderr of the internal process we'll be able to detect even console.log and crash logs from internal for better debuggability.

I believe that way it's also more performant instead of the previous process.send approach.