### PR TITLE
Allow a way to inject electron args for debug

### DIFF
--- a/tools/utils/Electron.js
+++ b/tools/utils/Electron.js
@@ -11,7 +11,9 @@ class Electron {
 
   start() {
     if (!this.instance) {
-      this.instance = execa(this.electronPath, [this.bundlePath]);
+      const args = (process.env.ELECTRON_ARGS || "").split(/[ ]+/).filter(Boolean);
+      if (args.length) console.log("electron starts with", args);
+      this.instance = execa(this.electronPath, [this.bundlePath, ...args]);
       this.instance.stdout.pipe(process.stdout);
     }
   }


### PR DESCRIPTION
When you start our app with this

```
ELECTRON_ARGS='--inspect-brk' yarn start
```

it allows to go `chrome://inspect`

and starts Profiling

--inspect-brk is great because it waits you start profiling before starting, so we can record the main boot. which is the essential part (the rest is pretty well optimized already, only the fs write is slow but it's expected)

Interestingly, we can notice we import things that should never be imported in main thread

<img width="828" alt="Capture d’écran 2020-01-26 à 17 55 05" src="https://user-images.githubusercontent.com/211411/73138646-7e1e2200-4065-11ea-8615-93d06d0a0444.png">
