### PR TITLE
Lazy load auto-updater

### DIFF
--- a/src/main/updater/index.js
+++ b/src/main/updater/index.js
@@ -1,76 +1,21 @@
 // @flow
-import { app, BrowserWindow } from "electron";
-import { autoUpdater } from "@ledgerhq/electron-updater";
 import logger from "~/logger";
-import { getMainWindow } from "~/main/window-lifecycle";
-import type { UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
 
-import createElectronAppUpdater from "./createElectronAppUpdater";
-
-const UPDATE_CHECK_IGNORE = Boolean(process.env.UPDATE_CHECK_IGNORE);
-const UPDATE_CHECK_FEED =
-  process.env.UPDATE_CHECK_FEED || "http://resources.live.ledger.app/public_resources/signatures";
-
-const sendStatus = (status: UpdateStatus, payload?: *) => {
-  const win = getMainWindow();
-
-  if (win) {
-    win.webContents.send("updater", { status, payload });
-  }
-};
-
-const handleDownload = async info => {
-  try {
-    sendStatus("checking");
-    const appUpdater = await createElectronAppUpdater({ feedURL: UPDATE_CHECK_FEED, info });
-    await appUpdater.verify();
-    sendStatus("check-success");
-  } catch (err) {
-    logger.critical(err);
-    if (UPDATE_CHECK_IGNORE) {
-      sendStatus("check-success");
-    } else {
-      sendStatus("error", err);
-    }
-  }
-};
-
-const init = () => {
-  autoUpdater.on("checking-for-update", () => sendStatus("checking-for-update"));
-  autoUpdater.on("update-available", info => sendStatus("update-available", info));
-  autoUpdater.on("update-not-available", info => sendStatus("update-not-available", info));
-  autoUpdater.on("download-progress", p => sendStatus("download-progress", p));
-  autoUpdater.on("update-downloaded", handleDownload);
-  autoUpdater.on("error", err => {
-    logger.error(err);
-  });
-
-  autoUpdater.autoInstallOnAppQuit = false;
-  autoUpdater.checkForUpdates();
-};
-
-const quitAndInstall = () => {
-  const browserWindows = BrowserWindow.getAllWindows();
-
-  // Fixes quitAndInstall not quitting on macOS, as suggested on
-  // https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-306709572
-  app.removeAllListeners("window-all-closed");
-  browserWindows.forEach(browserWindow => {
-    browserWindow.removeAllListeners("close");
-  });
-
-  autoUpdater.quitAndInstall();
-};
+let updater: { quitAndInstall?: () => void } = {};
 
 export default (type: string) => {
   console.log(type);
   switch (type) {
     case "init":
-      init();
+      updater = require("./init").default;
       break;
 
     case "quit-and-install":
-      quitAndInstall();
+      if (!updater.quitAndInstall) {
+        logger.error(`Auto-update error: quitAndInstall called before init`);
+      } else {
+        updater.quitAndInstall();
+      }
       break;
 
     default:

--- a/src/main/updater/init.js
+++ b/src/main/updater/init.js
@@ -1,0 +1,67 @@
+// @flow
+import { app, BrowserWindow } from "electron";
+import { autoUpdater } from "@ledgerhq/electron-updater";
+import logger from "~/logger";
+import { getMainWindow } from "~/main/window-lifecycle";
+import type { UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
+
+import createElectronAppUpdater from "./createElectronAppUpdater";
+
+const UPDATE_CHECK_IGNORE = Boolean(process.env.UPDATE_CHECK_IGNORE);
+const UPDATE_CHECK_FEED =
+  process.env.UPDATE_CHECK_FEED || "http://resources.live.ledger.app/public_resources/signatures";
+
+const sendStatus = (status: UpdateStatus, payload?: *) => {
+  const win = getMainWindow();
+
+  if (win) {
+    win.webContents.send("updater", { status, payload });
+  }
+};
+
+const handleDownload = async info => {
+  try {
+    sendStatus("checking");
+    const appUpdater = await createElectronAppUpdater({ feedURL: UPDATE_CHECK_FEED, info });
+    await appUpdater.verify();
+    sendStatus("check-success");
+  } catch (err) {
+    logger.critical(err);
+    if (UPDATE_CHECK_IGNORE) {
+      sendStatus("check-success");
+    } else {
+      sendStatus("error", err);
+    }
+  }
+};
+
+const init = () => {
+  autoUpdater.on("checking-for-update", () => sendStatus("checking-for-update"));
+  autoUpdater.on("update-available", info => sendStatus("update-available", info));
+  autoUpdater.on("update-not-available", info => sendStatus("update-not-available", info));
+  autoUpdater.on("download-progress", p => sendStatus("download-progress", p));
+  autoUpdater.on("update-downloaded", handleDownload);
+  autoUpdater.on("error", err => {
+    logger.error(err);
+  });
+
+  autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.checkForUpdates();
+};
+
+const quitAndInstall = () => {
+  const browserWindows = BrowserWindow.getAllWindows();
+
+  // Fixes quitAndInstall not quitting on macOS, as suggested on
+  // https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-306709572
+  app.removeAllListeners("window-all-closed");
+  browserWindows.forEach(browserWindow => {
+    browserWindow.removeAllListeners("close");
+  });
+
+  autoUpdater.quitAndInstall();
+};
+
+init();
+
+export default { quitAndInstall };


### PR DESCRIPTION
Sheds off ~400ms on app start-up.

~Testing that this didn't break the auto-update, I found out that the `<TopBanner>` is nearly entirely covered (hidden) by the top part of the window, probably a regression from #137, I need to check with @LFBarreto.~ Fixed in #145 