### PR TITLE
LL-2146 fixed graph in account grid item

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -84,21 +84,6 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      # - name: clean up
-      #   run: npx rimraf ./dist
-      # - name: install and rebuild
-      #   run: |
-      #     yarn --frozen-lockfile
-      #     yarn install-deps
-      # - name: build
-      #   run: |
-      #     set NODE_ENV=production
-      #     node ./tools/main.js build
-      # - name: nightly
-      #   run: |
-      #     set DEBUG=electron-builder
-      #     set NODE_ENV=production
-      #     npx electron-builder --config electron-builder-nightly.yml
       - uses: "./.github/actions/get-package-infos"
         id: version
       - name: upload windows

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -10,7 +10,7 @@ const template = [
     process.platform === "darwin",
     [
       {
-        label: app.getName(),
+        label: app.name,
         submenu: [
           { role: "hide" },
           { role: "hideothers" },

--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -165,7 +165,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
     if (chartRef.current) {
       chartRef.current.data = generatedData;
       chartRef.current.options = generateOptions;
-      chartRef.current.update(500);
+      chartRef.current.update(0);
     } else {
       chartRef.current = new ChartJs(canvasRef.current, {
         type: "line",

--- a/src/renderer/components/Chart2Preview/index.js
+++ b/src/renderer/components/Chart2Preview/index.js
@@ -88,6 +88,12 @@ const Chart = ({ height, data, color, valueKey = "value" }: Props) => {
       tooltips: {
         enabled: false,
       },
+      layout: {
+        padding: {
+          top: 4,
+          bottom: 4,
+        },
+      },
       animation: {
         duration: 0,
       },
@@ -121,8 +127,7 @@ const Chart = ({ height, data, color, valueKey = "value" }: Props) => {
               zeroLineColor: theme.text.shade10,
             },
             ticks: {
-              min: min * 0.8,
-              maxTicksLimit: 4,
+              beginAtZero: true,
             },
           },
         ],
@@ -148,9 +153,7 @@ const Chart = ({ height, data, color, valueKey = "value" }: Props) => {
   return (
     <canvas
       ref={canvasRef}
-      height={height}
       style={{
-        width: "100%",
         height,
       }}
     />

--- a/src/renderer/components/Chart2Preview/index.js
+++ b/src/renderer/components/Chart2Preview/index.js
@@ -43,7 +43,7 @@ import type { Data } from "./types";
 
 export type Props = {
   data: Data,
-  height?: number,
+  height: number,
   color?: string,
   valueKey?: string,
 };
@@ -76,6 +76,10 @@ const Chart = ({ height, data, color, valueKey = "value" }: Props) => {
     }),
     [color, data, valueKey],
   );
+
+  const min = useMemo(() => Math.min(...generatedData.datasets[0].data.map(d => d.y)), [
+    generatedData,
+  ]);
 
   const generateOptions = useMemo(
     () => ({
@@ -116,11 +120,15 @@ const Chart = ({ height, data, color, valueKey = "value" }: Props) => {
               drawBorder: false,
               zeroLineColor: theme.text.shade10,
             },
+            ticks: {
+              min: min * 0.8,
+              maxTicksLimit: 4,
+            },
           },
         ],
       },
     }),
-    [theme],
+    [min, theme.text.shade10, theme.text.shade60],
   );
 
   useLayoutEffect(() => {
@@ -128,15 +136,13 @@ const Chart = ({ height, data, color, valueKey = "value" }: Props) => {
       chartRef.current.data = generatedData;
       chartRef.current.options = generateOptions;
       chartRef.current.update(0);
+    } else {
+      chartRef.current = new ChartJs(canvasRef.current, {
+        type: "line",
+        data: generatedData,
+        options: generateOptions,
+      });
     }
-  }, [data, generateOptions, generatedData, valueKey]);
-
-  useLayoutEffect(() => {
-    chartRef.current = new ChartJs(canvasRef.current, {
-      type: "line",
-      data: generatedData,
-      options: generateOptions,
-    });
   }, [generateOptions, generatedData]);
 
   return (

--- a/src/renderer/screens/accounts/AccountGridItem/Body.js
+++ b/src/renderer/screens/accounts/AccountGridItem/Body.js
@@ -26,7 +26,7 @@ const Body = ({ account, range }: Props) => {
   const { history, countervalueAvailable, countervalueChange } = useSelector(state =>
     balanceHistoryWithCountervalueSelector(state, { account, range }),
   );
-  const bgColor = useTheme("theme.colors.palette.background.paper");
+  const bgColor = useTheme("colors.palette.background.paper");
   const currency = getAccountCurrency(account);
 
   return (


### PR DESCRIPTION
make sure the bottom of the graphs are aligned

in the ticket, I was supposed to enable value graph when countervalues are not available, however that logic was already present.

I did port some of the enhancement from Chat2 to Chart2Preview

### Type

Fix

### Context

LL-2146

### Parts of the app affected / Test plan

Accounts Page -> Grid Mode
