### PR TITLE
LL-2147 Remove menu bar  from windows/linux

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -3,78 +3,57 @@ import { getMainWindow } from "./window-lifecycle";
 
 const { DEV_TOOLS, DEV_TOOLS_MODE } = process.env;
 
-const props = (predicate, values, defaultValue = {}) => (predicate ? values : defaultValue);
-
 const template = [
-  ...props(
-    process.platform === "darwin",
-    [
-      {
-        label: app.name,
-        submenu: [
-          { role: "hide" },
-          { role: "hideothers" },
-          { role: "unhide" },
-          { type: "separator" },
-          { role: "quit" },
-        ],
-      },
+  {
+    label: app.name,
+    submenu: [
+      { role: "hide" },
+      { role: "hideothers" },
+      { role: "unhide" },
+      { type: "separator" },
+      { role: "quit" },
     ],
-    [],
-  ),
-  ...[
-    {
-      label: "Edit",
-      submenu: [
-        { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
-        { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
-        { type: "separator" },
-        { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
-        { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
-        { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
-        { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" },
-      ],
-    },
-  ],
-  ...props(
-    process.platform === "darwin" || __DEV__ || DEV_TOOLS,
-    [
-      {
-        role: "window",
-        submenu: [
-          ...props(
-            __DEV__ || DEV_TOOLS,
-            [
-              {
-                label: "Main Window Dev Tools",
-                click() {
-                  const mainWindow = getMainWindow();
-                  mainWindow.webContents.openDevTools({
-                    // mode = "right" | "bottom" | "undocked" | "detach"
-                    mode: DEV_TOOLS_MODE,
-                  });
-                },
+  },
+  {
+    label: "Edit",
+    submenu: [
+      { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
+      { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
+      { type: "separator" },
+      { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
+      { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+      { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+      { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" },
+    ],
+  },
+  {
+    role: "window",
+    submenu: [
+      ...(__DEV__ || DEV_TOOLS
+        ? [
+            {
+              label: "Main Window Dev Tools",
+              click() {
+                const mainWindow = getMainWindow();
+                mainWindow.webContents.openDevTools({
+                  mode: DEV_TOOLS_MODE,
+                });
               },
-              ...props(process.platform === "darwin", [{ type: "separator" }], []),
-            ],
-            [],
-          ),
-          ...props(
-            process.platform === "darwin",
-            [
-              { role: "close" },
-              { role: "minimize" },
-              { role: "zoom" },
-              { type: "separator" },
-              { role: "front" },
-            ],
-            [],
-          ),
-        ],
-      },
+            },
+            { type: "separator" },
+          ]
+        : []),
+      { role: "close" },
+      { role: "minimize" },
+      { role: "zoom" },
+      { type: "separator" },
+      { role: "front" },
     ],
-    [],
-  ),
+  },
 ];
 
-export default Menu.buildFromTemplate(template);
+/*
+ https://www.electronjs.org/docs/api/menu#menusetapplicationmenumenu
+ To get rid of the menubar on windows/linux we need `null` ↓
+*/
+export default process.platform === "darwin" ? Menu.buildFromTemplate(template) : null;


### PR DESCRIPTION
On the current version of Electron we need to call `setApplicationMenu` passing `null` in order to get rid of the menu bar on Linux and Windows according to [the docs](https://www.electronjs.org/docs/api/menu#menusetapplicationmenumenu) which meant the `menu` file could be simplified a bunch (Do we really need it? @MortalKastor). Also got rid of the scrollbars when the containers are no overflowing (scroll vs auto on the grow scroll component) since it seems there is no longer a possibility to have the overlay scrollbars since the flag was dropped. 

There may be some other options but for now, we are left with always visible when scrollable.

<img width="1700" alt="Screenshot 2020-01-28 at 14 45 49" src="https://user-images.githubusercontent.com/4631227/73278615-22ca6c00-41ec-11ea-9224-b670461de9a6.png">

### Type

Bug Fix + Ui Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2147

### Parts of the app affected / Test plan

On Windows and Linux builds, check that we don't have a menu bar under the title of the windows and that scrollbars are only visible if the content is scrollable and not always.