### PR TITLE
Broken stars with the new sorting

### DIFF
--- a/src/renderer/actions/general.js
+++ b/src/renderer/actions/general.js
@@ -18,6 +18,7 @@ import {
   getOrderAccounts,
   counterValueCurrencySelector,
   userThemeSelector,
+  starredAccountIdsSelector,
 } from "./../reducers/settings";
 import { accountsSelector, activeAccountsSelector } from "./../reducers/accounts";
 import type { State } from "./../reducers";
@@ -50,6 +51,7 @@ export const calculateCountervalueSelector = (state: State) => {
 export const sortAccountsComparatorSelector: OutputSelector<State, void, *> = createSelector(
   getOrderAccounts,
   calculateCountervalueSelector,
+  starredAccountIdsSelector,
   sortAccountsComparatorFromOrder,
 );
 

--- a/src/renderer/components/ContextMenu/AccountContextMenu.js
+++ b/src/renderer/components/ContextMenu/AccountContextMenu.js
@@ -10,6 +10,7 @@ import IconStar from "~/renderer/icons/Star";
 import IconAccountSettings from "~/renderer/icons/AccountSettings";
 import ContextMenuItem from "./ContextMenuItem";
 import { toggleStarAction } from "~/renderer/actions/settings";
+import { refreshAccountsOrdering } from "~/renderer/actions/general";
 
 type OwnProps = {
   account: AccountLike,
@@ -23,16 +24,25 @@ type Props = {
   withStar?: boolean,
   openModal: Function,
   toggleStarAction: Function,
+  refreshAccountsOrdering: Function,
 };
 
 const mapDispatchToProps = {
   openModal,
   toggleStarAction,
+  refreshAccountsOrdering,
 };
 
 class AccountContextMenu extends PureComponent<Props> {
   getContextMenuItems = () => {
-    const { openModal, account, parentAccount, withStar, toggleStarAction } = this.props;
+    const {
+      openModal,
+      account,
+      parentAccount,
+      withStar,
+      toggleStarAction,
+      refreshAccountsOrdering,
+    } = this.props;
     const items = [
       {
         label: "accounts.contextMenu.send",
@@ -50,7 +60,10 @@ class AccountContextMenu extends PureComponent<Props> {
       items.push({
         label: "accounts.contextMenu.star",
         Icon: IconStar,
-        callback: () => toggleStarAction(account.id),
+        callback: () => {
+          toggleStarAction(account.id);
+          refreshAccountsOrdering();
+        },
       });
     }
 

--- a/src/renderer/components/Stars/Star.js
+++ b/src/renderer/components/Stars/Star.js
@@ -10,6 +10,7 @@ import { rgba } from "~/renderer/styles/helpers";
 import starAnim from "~/renderer/images/starAnim.png";
 import starAnim2 from "~/renderer/images/starAnim2.png";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import { refreshAccountsOrdering } from "~/renderer/actions/general";
 
 const ButtonWrapper: ThemedComponent<{ filled?: boolean }> = styled.div`
   height: 34px;
@@ -33,37 +34,21 @@ const FloatingWrapper: ThemedComponent<{}> = styled.div``;
 const StarWrapper: ThemedComponent<{}> = styled.div`
   margin: -17px;
 `;
-
 const StarIcon: ThemedComponent<{
   filled?: boolean,
   yellow?: boolean,
-  showAnimation?: boolean,
 }> = styled.div.attrs(p => ({
   style: {
     backgroundPosition: p.filled ? "right" : "left",
-    animation: p.showAnimation ? "star-burst .8s steps(29) 1" : "none",
+    backgroundImage: `url("${p.yellow ? starAnim2 : starAnim}")`,
+    height: "50px",
+    width: "50px",
+    backgroundRepeat: "no-repeat",
+    backgroundSize: "3000%",
   },
 }))`
-  & {
-    height: 50px;
-    width: 50px;
-    background-image: url("${p => (p.yellow ? starAnim2 : starAnim)}");
-    background-repeat: no-repeat;
-    background-size: 3000%;
-    animation: none;
-  }
-
   &:hover {
     ${p => (!p.filled ? `background-position: -50px;` : "")}
-  }
-
-  @keyframes star-burst {
-    from {
-      background-position: left;
-    }
-    to {
-      background-position: right;
-    }
   }
 `;
 
@@ -73,6 +58,7 @@ const mapStateToProps = createStructuredSelector({
 
 const mapDispatchToProps = {
   toggleStarAction,
+  refreshAccountsOrdering,
 };
 
 type OwnProps = {
@@ -84,24 +70,36 @@ type Props = {
   ...OwnProps,
   isAccountStared: boolean,
   toggleStarAction: Function,
+  refreshAccountsOrdering: Function,
 };
 
-const Star = ({ accountId, isAccountStared, toggleStarAction, yellow }: Props) => {
+const Star = ({
+  accountId,
+  isAccountStared,
+  toggleStarAction,
+  yellow,
+  refreshAccountsOrdering,
+}: Props) => {
   const [showAnimation, setShowAnimation] = useState(false);
   const toggleStar = useCallback(
     e => {
       e.stopPropagation();
       setShowAnimation(!isAccountStared);
       toggleStarAction(accountId);
+      refreshAccountsOrdering();
     },
-    [accountId, toggleStarAction, isAccountStared],
+    [isAccountStared, toggleStarAction, accountId, refreshAccountsOrdering],
   );
   const MaybeButtonWrapper = yellow ? ButtonWrapper : FloatingWrapper;
 
   return (
     <MaybeButtonWrapper filled={isAccountStared}>
       <StarWrapper onClick={toggleStar}>
-        <StarIcon yellow={yellow} filled={isAccountStared} showAnimation={showAnimation} />
+        <StarIcon
+          yellow={yellow}
+          filled={isAccountStared}
+          className={showAnimation ? "star" : ""}
+        />
       </StarWrapper>
     </MaybeButtonWrapper>
   );

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -49,16 +49,3 @@ body {
   font-weight: 900;
   font-style: normal;
 }
-
-@keyframes star-burst {
-  from {
-    background-position: left;
-  }
-  to {
-    background-position: right;
-  }
-}
-
-.star{
-  animation: star-burst .8s steps(29) 1;
-}

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -49,3 +49,16 @@ body {
   font-weight: 900;
   font-style: normal;
 }
+
+@keyframes star-burst {
+  from {
+    background-position: left;
+  }
+  to {
+    background-position: right;
+  }
+}
+
+.star{
+  animation: star-burst .8s steps(29) 1;
+}


### PR DESCRIPTION
As a bit of background, the introduction of the new sorting param that prioritizes the starred accounts ahead of the rest a bug was uncovered in the way I implemented the star icon with the little animation. @LFBarreto mentioned that it also seems to be leaking an event listener if I understood correctly during the weekly.

This version here attempted to move the style that triggers the animation to a global class but perhaps that was the wrong direction to get this solved. Maybe by having unique classes linked to each element that has this star animation as mentioned by @IAmMorrow we could get this solved, I spent way too long on it so a new set of eyes would benefit us all.

Feel free to close this pr and open your own or work on this one 🙌 

If you do start from a new branch keep in mind that starring an account needs to dispatch the `refreshAccountsOrdering` or it will not reorder. Also @gre @aramab the fact that it reorders automagically is also weird in terms of UX since the thing I clicked goes somewhere else after I clicked.

Perhaps animating it, or fading it out of existence, I don't know.

In @IAmMorrow we trust.

### Type

Bug, not a bug fix, a bug.