### PR TITLE
LL-2069 Fix the input bug with trailing zeros

### DIFF
--- a/src/renderer/components/InputCurrency.js
+++ b/src/renderer/components/InputCurrency.js
@@ -49,6 +49,7 @@ type OwnProps = {
   subMagnitude?: number,
   allowZero?: boolean,
   disabled?: boolean,
+  autoFocus?: boolean,
 };
 
 type Props = {
@@ -77,6 +78,7 @@ class InputCurrency extends PureComponent<Props, State> {
     showAllDigits: false,
     subMagnitude: 0,
     allowZero: false,
+    autoFocus: false,
   };
 
   state = {
@@ -86,7 +88,7 @@ class InputCurrency extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    this.syncInput({ isFocused: false });
+    this.syncInput({ isFocused: !!this.props.autoFocus });
   }
 
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
Let's keep this fragile equilibrium we have with the `InputCurrency` component going a little bit longer

![itvorks](https://user-images.githubusercontent.com/4631227/73286682-44c9eb80-41f8-11ea-90d1-89558202d9bb.gif)

### Type
Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2069

### Parts of the app affected / Test plan

Any amount input in the app