### PR TITLE
Pause syncs when you enter Manager

### DIFF
--- a/src/renderer/screens/manager/index.js
+++ b/src/renderer/screens/manager/index.js
@@ -1,8 +1,14 @@
 // @flow
 import React from "react";
 import ManagerConnect from "~/renderer/components/ManagerConnect";
+import SyncSkipUnderPriority from "~/renderer/components/SyncSkipUnderPriority";
 import Dashboard from "~/renderer/screens/manager/Dashboard";
 
-const Manager = () => <ManagerConnect Success={Dashboard} />;
+const Manager = () => (
+  <>
+    <SyncSkipUnderPriority priority={999} />
+    <ManagerConnect Success={Dashboard} />
+  </>
+);
 
 export default Manager;


### PR DESCRIPTION
- syncs will finish but no new sync will happen when you are in manager
- Pause will likely display as a sync state and will continue once you go back again to accounts
