### PR TITLE
LL-2172 Fix RequestAmount countervalue inconsistency bug

### DIFF
--- a/src/renderer/components/InputCurrency.js
+++ b/src/renderer/components/InputCurrency.js
@@ -102,6 +102,7 @@ class InputCurrency extends PureComponent<Props, State> {
     if (needsToBeReformatted) {
       const { isFocused } = this.state;
       this.setState({
+        rawValue: "",
         displayValue:
           !nextProps.value || nextProps.value.isZero()
             ? ""


### PR DESCRIPTION
If a device receives new props and `needsToBeReformatted` it makes sense that we reset the internal `rawValue` too. Without doing this we ran into the linked issue.

### Fix demo
![glitchnomore](https://user-images.githubusercontent.com/4631227/73673133-6d495e00-46ae-11ea-9f92-0ebadf86a494.gif)

### Type
Bug fix

### Context
https://ledgerhq.atlassian.net/browse/LL-2172
