### PR TITLE
Update live-common 11.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ledgerhq/hw-transport-http": "^5.7.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.7.0",
     "@ledgerhq/ledger-core": "^5.3.2",
-    "@ledgerhq/live-common": "^11.4.0-beta.0",
+    "@ledgerhq/live-common": "^11.4.1",
     "@ledgerhq/logs": "^5.6.0",
     "@tippy.js/react": "^3.1.1",
     "@trust/keyto": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,10 +1298,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^11.4.0-beta.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.4.0.tgz#320860b886e6dc23bf279752f5166c2f304ba753"
-  integrity sha512-E9kdE0JQm4bPTVKsJ/EBBBIa/BjP+afhCVQFCULElWdv1KZ2gJMcPzxgplL6CrFRlOdTmx5vvgNEbSR2S5kSxg==
+"@ledgerhq/live-common@^11.4.1":
+  version "11.4.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.4.1.tgz#ad4382bc01e574413cf2fa80451c47156f03707a"
+  integrity sha512-mHKvf27zqOQxO4yor25wK1zbT35oaMRBxcok8YkxNPD8EZHBnBWVeL99PbSNkiWHktEZAULD62lbeXIp37tgJg==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.7.0"


### PR DESCRIPTION
Bump live common version to 11.4.1
- fixes issues on device socket and manager

### Parts of the app affected / Test plan

ManagerV2 on wipe and multiple scheduled actions.
