### PR TITLE
LL-2178 fixed error not passed to stepper props in update flow

### DIFF
--- a/src/renderer/modals/UpdateFirmwareModal/index.js
+++ b/src/renderer/modals/UpdateFirmwareModal/index.js
@@ -131,7 +131,7 @@ const UpdateModal = ({
     onCloseModal: onClose,
     setError,
     firmware,
-    error,
+    error: err,
     deviceModelId,
   };
 

--- a/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
@@ -7,9 +7,8 @@ import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import Button from "~/renderer/components/Button";
-import TranslatedError from "~/renderer/components/TranslatedError";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import CheckCircle from "~/renderer/icons/CheckCircle";
-import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import type { StepProps } from "../";
 
@@ -30,33 +29,7 @@ const Title = styled(Box).attrs(() => ({
 const StepConfirmation = ({ error }: StepProps) => {
   const { t } = useTranslation();
   if (error) {
-    return (
-      <Container>
-        <Box color="alertRed">
-          <ExclamationCircleThin size={44} />
-        </Box>
-        <Box
-          color="palette.text.shade100"
-          mt={4}
-          fontSize={5}
-          ff="Inter|Regular"
-          textAlign="center"
-          style={{ maxWidth: 350 }}
-        >
-          <TranslatedError error={error} field="title" />
-        </Box>
-        <Box
-          color="palette.text.shade80"
-          mt={4}
-          fontSize={4}
-          ff="Inter"
-          textAlign="center"
-          style={{ maxWidth: 350 }}
-        >
-          <TranslatedError error={error} field="description" />
-        </Box>
-      </Container>
-    );
+    return <ErrorDisplay error={error} withExportLogs />;
   }
 
   return (


### PR DESCRIPTION
Fixes the error screen on the firmware update modals 
I reused `ErrorDisplay` for the errors
To see the difference you can check the last screenshot (iso v1)

### Type

Fix

### Context

LL-2178 

### Parts of the app affected / Test plan

Firmware Update flows

#### with ErrorDisplay 
![Electron 2020-02-04 at 17 09 20](https://user-images.githubusercontent.com/671786/73763084-3d16c380-4771-11ea-9a93-5713058bef8b.png)
![Electron 2020-02-04 at 17 09 33](https://user-images.githubusercontent.com/671786/73763085-3d16c380-4771-11ea-9e68-848da0a850f8.png)

#### old school style
![Electron 2020-02-04 at 16 51 18](https://user-images.githubusercontent.com/671786/73763227-70f1e900-4771-11ea-9978-d1a1baf63f58.png)
