### PR TITLE
LL-2163 Better OS Language support

### DIFF
--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -6,6 +6,7 @@ import Transport from "@ledgerhq/hw-transport";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { checkLibs } from "@ledgerhq/live-common/lib/sanityChecks";
+import i18n from "i18next";
 import { remote, webFrame } from "electron";
 import { render } from "react-dom";
 import moment from "moment";
@@ -72,6 +73,7 @@ async function init() {
   const state = store.getState();
   const language = languageSelector(state);
   moment.locale(language);
+  i18n.changeLanguage(language);
 
   const hideEmptyTokenAccounts = hideEmptyTokenAccountsSelector(state);
   setEnvOnAllThreads("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccounts);

--- a/src/renderer/reducers/application.js
+++ b/src/renderer/reducers/application.js
@@ -1,15 +1,28 @@
 // @flow
 
 import { handleActions } from "redux-actions";
+import { getSystemLocale } from "~/helpers/systemLocale";
+import { getLanguages } from "~/config/languages";
+import type { LangAndRegion } from "~/renderer/reducers/settings";
 
 export type ApplicationState = {
   isLocked?: boolean,
   osDarkMode?: boolean,
+  osLanguage?: LangAndRegion,
   navigationLocked?: boolean,
 };
 
+const { language, region } = getSystemLocale();
+const languages = getLanguages();
+const osLangSupported = languages.includes(language);
+
 const state: ApplicationState = {
   osDarkMode: window.matchMedia("(prefers-color-scheme: dark)").matches,
+  osLanguage: {
+    language: osLangSupported ? language : "en",
+    region: osLangSupported ? region : "US",
+    useSystem: true,
+  },
 };
 
 const handlers = {
@@ -26,6 +39,8 @@ const handlers = {
 export const isLocked = (state: Object) => state.application.isLocked === true;
 
 export const osDarkModeSelector = (state: Object) => state.application.osDarkMode;
+
+export const osLangAndRegionSelector = (state: Object) => state.application.osLanguage;
 
 export const isNavigationLocked = (state: Object) => state.application.navigationLocked;
 

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -11,9 +11,9 @@ import {
 import type { DeviceModelId } from "@ledgerhq/devices";
 import type { CryptoCurrency, Currency } from "@ledgerhq/live-common/lib/types";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
-import { getSystemLocale } from "~/helpers/systemLocale";
 import { getLanguages } from "~/config/languages";
 import type { State } from ".";
+import { osLangAndRegionSelector } from "~/renderer/reducers/application";
 
 export type CurrencySettings = {
   confirmationsNb: number,
@@ -60,6 +60,8 @@ export const timeRangeDaysByKey = {
 };
 
 export type TimeRange = $Keys<typeof timeRangeDaysByKey>;
+
+export type LangAndRegion = { language: string, region: ?string, useSystem: boolean };
 
 export type SettingsState = {
   loaded: boolean, // is the settings loaded from db (it not we don't save them)
@@ -230,23 +232,23 @@ export const lastUsedVersionSelector = (state: State): string => state.settings.
 
 export const userThemeSelector = (state: State): ?string => state.settings.theme;
 
-export const langAndRegionSelector = (
+export const userLangAndRegionSelector = (
   state: State,
-): { language: string, region: ?string, useSystem: boolean } => {
+): ?{ language: string, region: ?string, useSystem: boolean } => {
   const languages = getLanguages();
-  let { language, region } = state.settings;
+  const { language, region } = state.settings;
   if (language && languages.includes(language)) {
     return { language, region, useSystem: false };
   }
-  const locale = getSystemLocale();
-  language = locale.language;
-  region = locale.region;
-  if (!language || !languages.includes(language)) {
-    language = "en";
-    region = "US";
-  }
-  return { language, region, useSystem: true };
 };
+
+export const langAndRegionSelector: OutputSelector<State, void, LangAndRegion> = createSelector(
+  userLangAndRegionSelector,
+  osLangAndRegionSelector,
+  (userLang, osLang) => {
+    return userLang || osLang;
+  },
+);
 
 export const languageSelector: OutputSelector<State, void, string> = createSelector(
   langAndRegionSelector,

--- a/src/renderer/screens/settings/sections/General/LanguageSelect.js
+++ b/src/renderer/screens/settings/sections/General/LanguageSelect.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { useMemo, useCallback } from "react";
-import moment from "moment";
 import { useTranslation } from "react-i18next";
 import { useSelector, useDispatch } from "react-redux";
 import { allLanguages, prodStableLanguages } from "~/config/languages";
@@ -26,7 +25,7 @@ type ChangeLangArgs = { value: LangKeys, label: string };
 
 const LanguageSelect = () => {
   const { useSystem, language } = useSelector(langAndRegionSelector);
-  const { i18n, t } = useTranslation();
+  const { t } = useTranslation();
   const dispatch = useDispatch();
 
   const debugLanguage = useEnv("EXPERIMENTAL_LANGUAGES");
@@ -49,11 +48,9 @@ const LanguageSelect = () => {
 
   const handleChangeLanguage = useCallback(
     ({ value: languageKey }: ChangeLangArgs) => {
-      i18n.changeLanguage(languageKey);
-      moment.locale(languageKey);
       dispatch(setLanguage(languageKey));
     },
-    [dispatch, i18n],
+    [dispatch],
   );
 
   return (


### PR DESCRIPTION
Moved the OS language to it's own selector like we did for the dark mode os settings and wrapped the language/region/both selector around the user and os ones, defaulting to the os language when the user selection is invalid (ie the user has chosen the os language)

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2163

### Notes
On mac I have to restart the computer for this os lang to change, the bug was not about that but rather the selector changes not working when going _back_ to the os system language from a different selection.