### PR TITLE
(TopBanner): fixed styling issue making it cropped

### DIFF
--- a/src/renderer/components/TopBanner.js
+++ b/src/renderer/components/TopBanner.js
@@ -26,7 +26,6 @@ const Container: ThemedComponent<{}> = styled(Box).attrs(p => ({
   px: 3,
   bg: p.theme.colors[p.status] || "palette.primary.main",
   color: "palette.primary.contrastText",
-  mt: -32,
   mb: 20,
   fontSize: 4,
   ff: "Inter|SemiBold",


### PR DESCRIPTION
Top banner was cropped, now fixed by removing unnecessary margin

**before:**
![localhost_8080_webpack_index html_](https://user-images.githubusercontent.com/11752937/73863950-217aee00-4841-11ea-88f2-ea63fd89f166.png)

**after:**
![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/73863966-263fa200-4841-11ea-9e2f-3d915265bd7d.png)


### Type

UI Polish

### Parts of the app affected / Test plan
Top Banner 
to reproduce run the app with `DEBUG_UPDATE=1 yarn start`
to toggle update debug tools
