### PR TITLE
Animate/Prevent animations for Chart2 when needed

### DIFF
--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -72,6 +72,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
   const chartRef = useRef(null);
   const theme = useTheme("colors.palette");
   const [tooltip, setTooltip] = useState();
+  const valueKeyRef = useRef(valueKey);
 
   const generatedData = useMemo(
     () => ({
@@ -103,6 +104,9 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
 
   const generateOptions = useMemo(
     () => ({
+      animation: {
+        duration: 0,
+      },
       responsive: true,
       maintainAspectRatio: false,
       tooltips: {
@@ -163,9 +167,15 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
 
   useLayoutEffect(() => {
     if (chartRef.current) {
-      chartRef.current.data = generatedData;
+      let shouldAnimate = false;
+      if (valueKeyRef.current !== valueKey) {
+        valueKeyRef.current = valueKey;
+        shouldAnimate = true;
+      }
+
+      chartRef.current.data.datasets[0].data = generatedData.datasets[0].data;
       chartRef.current.options = generateOptions;
-      chartRef.current.update(0);
+      chartRef.current.update(shouldAnimate ? 500 : 0);
     } else {
       chartRef.current = new ChartJs(canvasRef.current, {
         type: "line",
@@ -173,7 +183,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
         options: generateOptions,
       });
     }
-  }, [generateOptions, generatedData]);
+  }, [generateOptions, generatedData, valueKey]);
 
   return (
     <ChartContainer height={height}>


### PR DESCRIPTION
Following the specs from @aramab and @gre the chart should animation according to this:

✅ When toggling between fiat and crypto view
❌ When changing a range (week/month/year)
❌ When the rates change
❌ When we initially load a screen

### Type

UI Polish.