### PR TITLE
Infer whether user has set a password or not on init, drop the setting

### DIFF
--- a/src/main/db/index.js
+++ b/src/main/db/index.js
@@ -112,6 +112,14 @@ async function ensureNSLoaded(ns: string) {
 }
 
 /**
+ * In the event of a user refreshing the app we need to reload the data
+ * to ensure the lock/unlock detection is still valid.
+ */
+async function reload() {
+  DBPath && init(DBPath);
+}
+
+/**
  * Register a keyPath in db that is encrypted
  * This will decrypt the keyPath at this moment, and will be used
  * in `save` to encrypt it back
@@ -285,6 +293,7 @@ function getDBPath() {
 
 export default {
   init,
+  reload,
   load,
   registerTransform,
   setEncryptionKey,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -75,6 +75,10 @@ app.on("ready", async () => {
     return db.resetAll();
   });
 
+  ipcMain.handle("reload", () => {
+    return db.reload();
+  });
+
   ipcMain.handle("cleanCache", () => {
     return db.cleanCache();
   });

--- a/src/renderer/actions/application.js
+++ b/src/renderer/actions/application.js
@@ -1,8 +1,17 @@
 // @flow
 import { createAction } from "redux-actions";
 
-export const unlock = createAction("APPLICATION_SET_DATA", () => ({ isLocked: false }));
-export const lock = createAction("APPLICATION_SET_DATA", () => ({ isLocked: true }));
+export const unlock = createAction("APPLICATION_SET_DATA", () => ({
+  isLocked: false,
+  hasPassword: true,
+}));
+export const lock = createAction("APPLICATION_SET_DATA", () => ({
+  isLocked: true,
+  hasPassword: true,
+}));
+export const setHasPassword = createAction("APPLICATION_SET_DATA", hasPassword => ({
+  hasPassword,
+}));
 export const setOSDarkMode = createAction("APPLICATION_SET_DATA", osDarkMode => ({ osDarkMode }));
 export const setNavigationLock = createAction("APPLICATION_SET_DATA", navigationLocked => ({
   navigationLocked,

--- a/src/renderer/components/Idler.js
+++ b/src/renderer/components/Idler.js
@@ -10,7 +10,6 @@ import { useDebouncedCallback } from "~/renderer/hooks/useDebounce";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 
 const Idler = () => {
-  let timeout;
   const [lastAction, setLastAction] = useState(-1);
   const autoLockTimeout = useSelector(autoLockTimeoutSelector);
   const hasPassword = useSelector(hasPasswordSelector);
@@ -23,11 +22,11 @@ const Idler = () => {
 
   const checkForAutoLock = useCallback(() => {
     if (hasPassword && autoLockTimeout && autoLockTimeout !== -1) {
-      if (Date.now() - (lastAction + timeout + 60000) > 0) {
+      if (Date.now() - (lastAction + autoLockTimeout + 60000) > 0) {
         dispatch(lock());
       }
     }
-  }, [autoLockTimeout, dispatch, hasPassword, lastAction, timeout]);
+  }, [autoLockTimeout, dispatch, hasPassword, lastAction]);
 
   // onMount & willUnmount
   useEffect(() => {

--- a/src/renderer/components/Idler.js
+++ b/src/renderer/components/Idler.js
@@ -2,11 +2,12 @@
 import { useEffect, useCallback, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
-import { hasPasswordSelector, autoLockTimeoutSelector } from "~/renderer/reducers/settings";
+import { autoLockTimeoutSelector } from "~/renderer/reducers/settings";
 import { lock } from "~/renderer/actions/application";
 
 import useInterval from "~/renderer/hooks/useInterval";
 import { useDebouncedCallback } from "~/renderer/hooks/useDebounce";
+import { hasPasswordSelector } from "~/renderer/reducers/application";
 
 const Idler = () => {
   let timeout;

--- a/src/renderer/components/TopBar/index.js
+++ b/src/renderer/components/TopBar/index.js
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import { lock } from "~/renderer/actions/application";
 import { openModal } from "~/renderer/actions/modals";
 
-import { discreetModeSelector, hasPasswordSelector } from "~/renderer/reducers/settings";
+import { discreetModeSelector } from "~/renderer/reducers/settings";
 import { hasAccountsSelector } from "~/renderer/reducers/accounts";
 
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -29,6 +29,7 @@ import IconSettings from "~/renderer/icons/Settings";
 import ActivityIndicator from "./ActivityIndicator";
 import ItemContainer from "./ItemContainer";
 import { setDiscreetMode } from "~/renderer/actions/settings";
+import { hasPasswordSelector } from "~/renderer/reducers/application";
 
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({}))`
   height: ${p => p.theme.sizes.topBarHeight}px;

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -10,7 +10,7 @@ import i18n from "i18next";
 import { remote, webFrame } from "electron";
 import { render } from "react-dom";
 import moment from "moment";
-import { getKey } from "~/renderer/storage";
+import { reload, getKey } from "~/renderer/storage";
 
 import "~/renderer/styles/global";
 import "~/renderer/live-common-setup";
@@ -83,11 +83,11 @@ async function init() {
 
   const isMainWindow = remote.getCurrentWindow().name === "MainWindow";
 
-  if (initialSettings.hasPassword) {
-    store.dispatch(lock());
-  } else {
-    const accounts = await getKey("app", "accounts", []);
+  const accounts = await getKey("app", "accounts", []);
+  if (accounts) {
     await store.dispatch(setAccounts(accounts));
+  } else {
+    store.dispatch(lock());
   }
 
   r(<ReactRoot store={store} language={language} />);
@@ -113,6 +113,11 @@ async function init() {
 
     window.addEventListener("click", () => {
       if (isGlobalTabEnabled()) disableGlobalTab();
+    });
+
+    window.addEventListener("beforeunload", async () => {
+      // This event is triggered when we reload the app, we want it to forget what it knows
+      reload();
     });
   }
 

--- a/src/renderer/middlewares/db.js
+++ b/src/renderer/middlewares/db.js
@@ -27,11 +27,14 @@ export default (store: any) => (next: any) => (action: any) => {
     const oldState = store.getState();
     const res = next(action);
     const newState = store.getState();
-    if (oldState.countervalues !== newState.countervalues) {
-      setKey("app", "countervalues", CounterValues.exportSelector(newState));
-    }
-    if (areSettingsLoaded(newState) && oldState.settings !== newState.settings) {
-      setKey("app", "settings", settingsExportSelector(newState));
+    // NB Prevent write attempts when the app is locked.
+    if (!oldState.application.isLocked || action.type === "APPLICATION_SET_DATA") {
+      if (oldState.countervalues !== newState.countervalues) {
+        setKey("app", "countervalues", CounterValues.exportSelector(newState));
+      }
+      if (areSettingsLoaded(newState) && oldState.settings !== newState.settings) {
+        setKey("app", "settings", settingsExportSelector(newState));
+      }
     }
     return res;
   }

--- a/src/renderer/modals/DisablePasswordModal/index.js
+++ b/src/renderer/modals/DisablePasswordModal/index.js
@@ -5,13 +5,13 @@ import { useDispatch } from "react-redux";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { useTranslation } from "react-i18next";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
-import { saveSettings } from "~/renderer/actions/settings";
 import { closeModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import InputPassword from "~/renderer/components/InputPassword";
 import Label from "~/renderer/components/Label";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
+import { setHasPassword } from "~/renderer/actions/application";
 
 type MaybePasswordIncorrectError = ?PasswordIncorrectError;
 
@@ -33,10 +33,10 @@ const DisablePasswordModal = () => {
   const setPassword = useCallback(
     async (password: ?string) => {
       if (password) {
-        dispatch(saveSettings({ hasPassword: true }));
+        dispatch(setHasPassword(true));
         await setEncryptionKey("app", "accounts", password);
       } else {
-        dispatch(saveSettings({ hasPassword: false }));
+        dispatch(setHasPassword(false));
         await removeEncryptionKey("app", "accounts");
       }
     },

--- a/src/renderer/modals/PasswordModal/index.js
+++ b/src/renderer/modals/PasswordModal/index.js
@@ -4,14 +4,14 @@ import React, { useState, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
-import { saveSettings } from "~/renderer/actions/settings";
-import { hasPasswordSelector } from "~/renderer/reducers/settings";
 import { closeModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import PasswordForm from "./PasswordForm";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
+import { hasPasswordSelector } from "~/renderer/reducers/application";
+import { setHasPassword } from "~/renderer/actions/application";
 
 type MaybePasswordIncorrectError = ?PasswordIncorrectError;
 
@@ -32,10 +32,10 @@ const PasswordModal = () => {
   const setPassword = useCallback(
     async (password: ?string) => {
       if (password) {
-        dispatch(saveSettings({ hasPassword: true }));
+        dispatch(setHasPassword(true));
         await setEncryptionKey("app", "accounts", password);
       } else {
-        dispatch(saveSettings({ hasPassword: false }));
+        dispatch(setHasPassword(false));
         await removeEncryptionKey("app", "accounts");
       }
     },

--- a/src/renderer/reducers/application.js
+++ b/src/renderer/reducers/application.js
@@ -7,6 +7,7 @@ import type { LangAndRegion } from "~/renderer/reducers/settings";
 
 export type ApplicationState = {
   isLocked?: boolean,
+  hasPassword?: boolean,
   osDarkMode?: boolean,
   osLanguage?: LangAndRegion,
   navigationLocked?: boolean,
@@ -23,6 +24,7 @@ const state: ApplicationState = {
     region: osLangSupported ? region : "US",
     useSystem: true,
   },
+  hasPassword: false,
 };
 
 const handlers = {
@@ -37,6 +39,8 @@ const handlers = {
 // Selectors
 
 export const isLocked = (state: Object) => state.application.isLocked === true;
+
+export const hasPasswordSelector = (state: Object) => state.application.hasPassword === true;
 
 export const osDarkModeSelector = (state: Object) => state.application.osDarkMode;
 

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -74,7 +74,6 @@ export type SettingsState = {
   region: ?string,
   orderAccounts: string,
   countervalueFirst: boolean,
-  hasPassword: boolean,
   autoLockTimeout: number,
   selectedTimeRange: TimeRange,
   marketIndicator: "eastern" | "western",
@@ -113,7 +112,6 @@ const INITIAL_STATE: SettingsState = {
   region: null,
   orderAccounts: "balance|desc",
   countervalueFirst: false,
-  hasPassword: false,
   autoLockTimeout: 10,
   selectedTimeRange: "month",
   marketIndicator: "western",
@@ -206,8 +204,6 @@ const handlers: Object = {
 export const storeSelector = (state: State): SettingsState => state.settings;
 
 export const settingsExportSelector = storeSelector;
-
-export const hasPasswordSelector = (state: State): boolean => state.settings.hasPassword === true;
 
 export const discreetModeSelector = (state: State): boolean => state.settings.discreetMode === true;
 

--- a/src/renderer/screens/onboarding/index.js
+++ b/src/renderer/screens/onboarding/index.js
@@ -23,7 +23,7 @@ import {
 import GenuineCheck from "~/renderer/screens/onboarding/steps/GenuineCheck";
 import { saveSettings } from "~/renderer/actions/settings";
 import { openModal } from "~/renderer/actions/modals";
-import { unlock } from "~/renderer/actions/application";
+import { setHasPassword, unlock } from "~/renderer/actions/application";
 import Box from "~/renderer/components/Box";
 import IconCross from "~/renderer/icons/Cross";
 import Start from "./steps/Start";
@@ -67,6 +67,7 @@ const mapDispatchToProps = {
   openModal,
   relaunchOnboarding,
   updateGenuineCheck,
+  setHasPassword,
 };
 
 type Props = {
@@ -84,6 +85,7 @@ type Props = {
   openModal: string => void,
   relaunchOnboarding: boolean => void,
   updateGenuineCheck: (*) => void,
+  setHasPassword: Function,
 };
 
 export type StepProps = {
@@ -95,12 +97,12 @@ export type StepProps = {
   jumpStep: Function,
   finish: Function,
   saveSettings: Function,
-  savePassword: Function,
   getDeviceInfo: Function,
   updateGenuineCheck: Function,
   openModal: Function,
   deviceModelId: DeviceModelId => *,
   flowType: Function,
+  setHasPassword: Function,
 };
 
 const CloseContainer = styled(Box).attrs(() => ({
@@ -132,16 +134,6 @@ class OnboardingC extends PureComponent<Props> {
     this.props.relaunchOnboarding(false);
   };
 
-  savePassword = hash => {
-    this.props.saveSettings({
-      password: {
-        isEnabled: hash !== undefined,
-        value: hash,
-      },
-    });
-    this.props.unlock();
-  };
-
   render() {
     const {
       onboarding,
@@ -152,6 +144,7 @@ class OnboardingC extends PureComponent<Props> {
       t,
       onboardingRelaunched,
       updateGenuineCheck,
+      setHasPassword,
     } = this.props;
 
     const StepComponent = STEPS[onboarding.stepName];
@@ -174,9 +167,9 @@ class OnboardingC extends PureComponent<Props> {
       nextStep,
       jumpStep,
       finish: this.finish,
-      savePassword: this.savePassword,
       getDeviceInfo: this.getDeviceInfo,
       saveSettings,
+      setHasPassword,
     };
 
     return (

--- a/src/renderer/screens/onboarding/steps/Analytics.js
+++ b/src/renderer/screens/onboarding/steps/Analytics.js
@@ -16,8 +16,10 @@ import Switch from "~/renderer/components/Switch";
 import OnboardingFooter from "../OnboardingFooter";
 import { Description, FixedTopContainer, StepContainerInner, Title } from "../sharedComponents";
 import type { StepProps } from "..";
+import { removeEncryptionKey } from "~/renderer/storage";
+import { setHasPassword } from "~/renderer/actions/application";
 
-const mapDispatchToProps = { saveSettings, openModal };
+const mapDispatchToProps = { saveSettings, openModal, setHasPassword };
 
 type State = {
   analyticsToggle: boolean,
@@ -50,8 +52,9 @@ class Analytics extends PureComponent<StepProps, State> {
   onClickPrivacy = () => openURL(urls.privacyPolicy);
 
   handleNavBack = () => {
-    const { savePassword, prevStep } = this.props;
-    savePassword(undefined);
+    const { prevStep, setHasPassword } = this.props;
+    removeEncryptionKey("app", "accounts");
+    setHasPassword(false);
     prevStep();
   };
 

--- a/src/renderer/screens/onboarding/steps/SetPassword.js
+++ b/src/renderer/screens/onboarding/steps/SetPassword.js
@@ -3,7 +3,6 @@
 import React, { PureComponent } from "react";
 import { connect } from "react-redux";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { saveSettings } from "~/renderer/actions/settings";
 import { setEncryptionKey } from "~/renderer/storage";
 import IconChevronRight from "~/renderer/icons/ChevronRight";
 import {
@@ -20,6 +19,9 @@ import PasswordForm from "~/renderer/modals/PasswordModal/PasswordForm";
 import Button from "~/renderer/components/Button";
 import { withTheme } from "styled-components";
 import type { StepProps } from "~/renderer/screens/onboarding";
+import { setHasPassword } from "~/renderer/actions/application";
+import { hasPasswordSelector } from "~/renderer/reducers/application";
+import { createStructuredSelector } from "reselect";
 
 type State = {
   currentPassword: string,
@@ -28,8 +30,12 @@ type State = {
 };
 
 const mapDispatchToProps = {
-  saveSettings,
+  setHasPassword,
 };
+
+const mapStateToProps = createStructuredSelector({
+  hasPasswordSelector,
+});
 
 const INITIAL_STATE = {
   currentPassword: "",
@@ -38,7 +44,8 @@ const INITIAL_STATE = {
 };
 
 type Props = StepProps & {
-  saveSettings: any => void,
+  hasPassword: boolean,
+  setHasPassword: boolean => void,
   theme: any,
 };
 
@@ -53,10 +60,10 @@ class SetPassword extends PureComponent<Props, State> {
       return;
     }
     const { newPassword } = this.state;
-    const { nextStep, saveSettings } = this.props;
+    const { nextStep, setHasPassword } = this.props;
 
     await setEncryptionKey("app", "accounts", newPassword);
-    saveSettings({ hasPassword: true });
+    setHasPassword(true);
     this.handleReset();
     nextStep();
   };
@@ -73,10 +80,8 @@ class SetPassword extends PureComponent<Props, State> {
   };
 
   render() {
-    const { nextStep, prevStep, t, settings, onboarding, theme } = this.props;
+    const { nextStep, prevStep, t, onboarding, theme, hasPassword } = this.props;
     const { newPassword, currentPassword, confirmPassword } = this.state;
-
-    const hasPassword = settings.hasPassword === true;
 
     const disclaimerNotes = [
       {
@@ -157,6 +162,6 @@ class SetPassword extends PureComponent<Props, State> {
 }
 
 const ConnectedSetPassword: React$ComponentType<{}> = withTheme(
-  connect(null, mapDispatchToProps)(SetPassword),
+  connect(mapStateToProps, mapDispatchToProps)(SetPassword),
 );
 export default ConnectedSetPassword;

--- a/src/renderer/screens/settings/sections/General/PasswordButton.js
+++ b/src/renderer/screens/settings/sections/General/PasswordButton.js
@@ -2,12 +2,12 @@
 import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { hasPasswordSelector } from "~/renderer/reducers/settings";
 import { openModal } from "~/renderer/actions/modals";
 import Switch from "~/renderer/components/Switch";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import Track from "~/renderer/analytics/Track";
+import { hasPasswordSelector } from "~/renderer/reducers/application";
 
 const PasswordButton = () => {
   const dispatch = useDispatch();

--- a/src/renderer/screens/settings/sections/General/index.js
+++ b/src/renderer/screens/settings/sections/General/index.js
@@ -4,7 +4,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { EXPERIMENTAL_MARKET_INDICATOR_SETTINGS } from "~/config/constants";
-import { hasPasswordSelector, langAndRegionSelector } from "~/renderer/reducers/settings";
+import { langAndRegionSelector } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import IconDisplay from "~/renderer/icons/Display";
 import {
@@ -22,6 +22,7 @@ import PasswordButton from "./PasswordButton";
 import PasswordAutoLockSelect from "./PasswordAutoLockSelect";
 import SentryLogsButton from "./SentryLogsButton";
 import ShareAnalyticsButton from "./ShareAnalyticsButton";
+import { hasPasswordSelector } from "~/renderer/reducers/application";
 
 const SectionGeneral = () => {
   const { useSystem } = useSelector(langAndRegionSelector);

--- a/src/renderer/storage.js
+++ b/src/renderer/storage.js
@@ -13,7 +13,11 @@ import debounce from "lodash/debounce";
 const transforms = {};
 
 transforms.accounts = {
-  get: (raws: *) => (raws || []).map(accountModel.decode),
+  get: (raws: *) => {
+    // NB to prevent parsing encrypted string as JSON
+    if (typeof raws === "string") return null;
+    return (raws || []).map(accountModel.decode);
+  },
   set: (accounts: *) => (accounts || []).map(accountModel.encode),
 };
 
@@ -61,5 +65,7 @@ export const hasBeenDecrypted = (ns: string, keyPath: string) =>
   ipcRenderer.invoke("hasBeenDecrypted", { ns, keyPath });
 
 export const resetAll = () => ipcRenderer.invoke("resetAll");
+
+export const reload = () => ipcRenderer.invoke("reload");
 
 export const cleanCache = () => ipcRenderer.invoke("cleanCache");


### PR DESCRIPTION
### Type
Bug fix

### What was the original bug
If we set a password or removed an existing one and quickly refreshed or closed the application this password flag/change was persisted but the associated data was not encrypted/decrypted accordingly, giving an error on further read attempts. This pr drops the need for that flag (there's still a runtime application state level flag) and will determine whether the app is locked or not by attempting to read the data.

For a refresh of the app using cmd + r we had to introduce a nuke to the cache of the loaded data forcing a new fetch to ensure that this inference of the lock state wasn't broken. I consulted with @meriadec before implementing this since he wrote the original persistence layer back in the day.

### How to test
Since this change affects the way we detect if the application is currently locked or not, we need to cover all the scenarios that involve a password change or interaction with it:
- Onboarding on a fresh install we have the opportunity to set a password
- Setting up a password in the settings of the app
- Locking the app at any point and confirming it's locked on refresh and relaunch
- Changing the password / removing the password and making sure that the password is still correct.

In addition to the initial scope of the pr and following the request from @gre it also includes a drop in the write attempts to the app.json file when the app is locked. This was invalidating the counter values cache if I understood it correctly and it affected performance. I don't know how to test this other than looking at the file size of app.json before locking the app and seeing if it grows (it shouldn't while locked)