### PR TITLE
(ManagerV2): cancel actions removed + flow fixes

### DIFF
--- a/src/renderer/screens/manager/AppsList/AppsList.js
+++ b/src/renderer/screens/manager/AppsList/AppsList.js
@@ -56,9 +56,8 @@ type Props = {
   deviceInfo: DeviceInfo,
   state: State,
   dispatch: Action => void,
-  plan: AppOp[],
   isIncomplete: boolean,
-  progress: *,
+  progress: ?{ appOp: AppOp, progress: number },
   setAppInstallDep: () => void,
   setAppUninstallDep: () => void,
   t: TFunction,
@@ -68,7 +67,6 @@ const AppsList = ({
   deviceInfo,
   state,
   dispatch,
-  plan,
   isIncomplete,
   progress = {},
   setAppInstallDep,
@@ -110,18 +108,18 @@ const AppsList = ({
         state={state}
         key={`${appStoreView ? "APP_STORE" : "DEVICE_TAB"}_${app.name}`}
         app={app}
+        installed={state.installed.find(({ name }) => name === app.name)}
         dispatch={dispatch}
         forceUninstall={isIncomplete}
         appStoreView={appStoreView}
         onlyUpdate={onlyUpdate}
         showActions={showActions}
-        scheduled={plan.find(a => a.name === app.name)}
-        progress={get(progress, ["appOp", "name"]) === app.name ? progress : null}
+        progress={get(progress, ["appOp", "name"]) === app.name ? progress : undefined}
         setAppInstallDep={setAppInstallDep}
         setAppUninstallDep={setAppUninstallDep}
       />
     ),
-    [state, dispatch, isIncomplete, plan, progress, setAppInstallDep, setAppUninstallDep],
+    [state, dispatch, isIncomplete, progress, setAppInstallDep, setAppUninstallDep],
   );
 
   return (

--- a/src/renderer/screens/manager/AppsList/Item.js
+++ b/src/renderer/screens/manager/AppsList/Item.js
@@ -7,6 +7,9 @@ import {
 } from "@ledgerhq/live-common/lib/apps";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/lib/currencies";
 import { isCurrencySupported } from "@ledgerhq/live-common/lib/data/cryptocurrencies";
+import type { App } from "@ledgerhq/live-common/lib/types/manager";
+import type { State, Action, InstalledItem, AppOp } from "@ledgerhq/live-common/lib/apps/types";
+
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 import manager from "@ledgerhq/live-common/lib/manager";
@@ -57,104 +60,110 @@ const LiveCompatible = styled.div`
   }
 `;
 
-type Props = *; // FIXME
+type Props = {
+  state: State,
+  app: App,
+  installed: ?InstalledItem,
+  dispatch: Action => void,
+  appStoreView: boolean,
+  onlyUpdate?: boolean,
+  forceUninstall?: boolean,
+  showActions?: boolean,
+  progress: ?{ appOp: AppOp, progress: number },
+  setAppInstallDep?: App => void,
+  setAppUninstallDep?: App => void,
+};
 
 // eslint-disable-next-line react/display-name
-const Item: React$ComponentType<Props> = React.memo(
-  ({
-    state,
-    app,
-    dispatch,
-    appStoreView,
-    onlyUpdate,
-    forceUninstall,
-    showActions = true,
-    scheduled,
-    progress,
-    setAppInstallDep,
-    setAppUninstallDep,
-  }: Props) => {
-    const { name } = app;
-    const { installed, deviceModel } = state;
+const Item: React$ComponentType<Props> = ({
+  state,
+  app,
+  installed,
+  dispatch,
+  appStoreView,
+  onlyUpdate,
+  forceUninstall,
+  showActions = true,
+  progress,
+  setAppInstallDep,
+  setAppUninstallDep,
+}: Props) => {
+  const { name } = app;
+  const { deviceModel } = state;
 
-    const notEnoughMemoryToInstall = useMemo(
-      () => isOutOfMemoryState(predictOptimisticState(reducer(state, { type: "install", name }))),
-      [name, state],
-    );
+  const notEnoughMemoryToInstall = useMemo(
+    () => isOutOfMemoryState(predictOptimisticState(reducer(state, { type: "install", name }))),
+    [name, state],
+  );
 
-    const isLiveSupported =
-      app.currencyId && isCurrencySupported(getCryptoCurrencyById(app.currencyId));
+  const isLiveSupported =
+    app.currencyId && isCurrencySupported(getCryptoCurrencyById(app.currencyId));
 
-    return (
-      <AppRow>
-        <Box flex="1" horizontal>
-          <img alt="" src={manager.getIconUrl(app.icon)} width={40} height={40} />
-          <AppName>
-            <Text ff="Inter|Bold" color="palette.text.shade100" fontSize={3}>{`${app.name}${
-              app.currencyId ? ` (${getCryptoCurrencyById(app.currencyId).ticker})` : ""
-            }`}</Text>
-            <Text ff="Inter|Regular" color="palette.text.shade50" fontSize={3}>
-              <Trans
-                i18nKey={
-                  installed && !installed.updated
-                    ? "manager.applist.item.versionNew"
-                    : "manager.applist.item.version"
-                }
-                values={{ version: app.version }}
-              />
-            </Text>
-          </AppName>
-        </Box>
-        <AppSize>
-          <ByteSize
-            value={
-              ((installed && installed.blocks) || 0) * deviceModel.deviceSize || app.bytes || 0
-            }
-            deviceModel={deviceModel}
-          />
-        </AppSize>
-        <Box flex="0.5" horizontal alignContent="center" justifyContent="center">
-          <LiveCompatible>
-            {isLiveSupported ? (
-              <Tooltip content={<Trans i18nKey="manager.applist.item.supported" />}>
-                <IconLoader size={16} />
-              </Tooltip>
-            ) : null}
-          </LiveCompatible>
-        </Box>
-        <AppActions
-          state={state}
-          app={app}
-          scheduled={scheduled}
-          dispatch={dispatch}
-          forceUninstall={forceUninstall}
-          appStoreView={appStoreView}
-          onlyUpdate={onlyUpdate}
-          showActions={showActions}
-          notEnoughMemoryToInstall={notEnoughMemoryToInstall}
-          progress={progress}
-          setAppInstallDep={setAppInstallDep}
-          setAppUninstallDep={setAppUninstallDep}
+  return (
+    <AppRow>
+      <Box flex="1" horizontal>
+        <img alt="" src={manager.getIconUrl(app.icon)} width={40} height={40} />
+        <AppName>
+          <Text ff="Inter|Bold" color="palette.text.shade100" fontSize={3}>{`${app.name}${
+            app.currencyId ? ` (${getCryptoCurrencyById(app.currencyId).ticker})` : ""
+          }`}</Text>
+          <Text ff="Inter|Regular" color="palette.text.shade50" fontSize={3}>
+            <Trans
+              i18nKey={
+                installed && !installed.updated
+                  ? "manager.applist.item.versionNew"
+                  : "manager.applist.item.version"
+              }
+              values={{ version: app.version }}
+            />
+          </Text>
+        </AppName>
+      </Box>
+      <AppSize>
+        <ByteSize
+          value={((installed && installed.blocks) || 0) * deviceModel.blockSize || app.bytes || 0}
+          deviceModel={deviceModel}
         />
-      </AppRow>
-    );
-  },
-);
+      </AppSize>
+      <Box flex="0.5" horizontal alignContent="center" justifyContent="center">
+        <LiveCompatible>
+          {isLiveSupported ? (
+            <Tooltip content={<Trans i18nKey="manager.applist.item.supported" />}>
+              <IconLoader size={16} />
+            </Tooltip>
+          ) : null}
+        </LiveCompatible>
+      </Box>
+      <AppActions
+        state={state}
+        app={app}
+        installed={installed}
+        dispatch={dispatch}
+        forceUninstall={forceUninstall}
+        appStoreView={appStoreView}
+        onlyUpdate={onlyUpdate}
+        showActions={showActions}
+        notEnoughMemoryToInstall={notEnoughMemoryToInstall}
+        progress={progress}
+        setAppInstallDep={setAppInstallDep}
+        setAppUninstallDep={setAppUninstallDep}
+      />
+    </AppRow>
+  );
+};
 
 export default memo<Props>(
   Item,
   (
     {
       state: { installQueue: _installQueue, uninstallQueue: _uninstallQueue },
-      scheduled: _scheduled,
       progress: _progress,
     },
-    { state: { installQueue, uninstallQueue }, scheduled, progress },
+    { state: { installQueue, uninstallQueue }, progress },
   ) => {
     /** compare _prev to next props that if different should trigger a rerender */
     return (
       progress === _progress &&
-      scheduled === _scheduled &&
       installQueue.length === _installQueue.length &&
       uninstallQueue.length === _uninstallQueue.length
     );

--- a/src/renderer/screens/manager/AppsList/Progress.js
+++ b/src/renderer/screens/manager/AppsList/Progress.js
@@ -1,14 +1,13 @@
 // @flow
-import React, { useCallback } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 
-import type { Action, AppOp } from "@ledgerhq/live-common/lib/apps/types";
+import type { AppOp } from "@ledgerhq/live-common/lib/apps/types";
 
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import ProgressBar from "~/renderer/components/Progress";
-import IconCrossCircle from "~/renderer/icons/CrossCircle";
 
 const Holder = styled.div`
   width: 100px;
@@ -18,34 +17,12 @@ const Holder = styled.div`
   overflow: hidden;
 `;
 
-const Cancel = styled.div`
-  align-items: center;
-  justify-content: center;
-  display: flex;
-  cursor: pointer;
-  margin-left: 4px;
-  color: ${p => p.theme.colors.palette.primary.main};
-`;
-
 type Props = {
-  name: string,
-  dispatch: Action => void,
-  scheduled: AppOp,
-  currentProgress?: { appOp: AppOp, progress: number },
+  currentProgress: ?{ appOp: AppOp, progress: number },
 };
 
-const Progress = ({ name, dispatch, scheduled, currentProgress }: Props) => {
+const Progress = ({ currentProgress }: Props) => {
   const { progress, appOp } = currentProgress || {};
-
-  const onInstall = useCallback(() => dispatch({ type: "install", name }), [dispatch, name]);
-  const onUninstall = useCallback(() => dispatch({ type: "uninstall", name }), [dispatch, name]);
-
-  const onClick = useCallback(() => {
-    if (scheduled) {
-      if (scheduled.type === "install") onUninstall();
-      if (scheduled.type === "uninstall") onInstall();
-    }
-  }, [scheduled, onInstall, onUninstall]);
 
   return (
     <Box flex="1" horizontal justifyContent="flex-end" overflow="hidden">
@@ -69,11 +46,6 @@ const Progress = ({ name, dispatch, scheduled, currentProgress }: Props) => {
               }
             />
           </Text>
-          {!progress ? (
-            <Cancel onClick={onClick}>
-              <IconCrossCircle size={20} />
-            </Cancel>
-          ) : null}
         </Box>
         <Holder>
           {appOp ? (

--- a/src/renderer/screens/manager/AppsList/UpdateAllApps.js
+++ b/src/renderer/screens/manager/AppsList/UpdateAllApps.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import { Trans } from "react-i18next";
 
-import type { State, AppOp, Action } from "@ledgerhq/live-common/lib/apps/types";
+import type { State, Action, AppOp } from "@ledgerhq/live-common/lib/apps/types";
 
 import CollapsibleCard from "~/renderer/components/CollapsibleCard";
 import Text from "~/renderer/components/Text";
@@ -50,12 +50,11 @@ const ProgressHolder = styled.div`
 type Props = {
   state: State,
   dispatch: Action => void,
-  plan: AppOp[],
   isIncomplete: boolean,
-  progress: *,
+  progress: ?{ appOp: AppOp, progress: number },
 };
 
-const UpdateAllApps = ({ state, dispatch, plan, isIncomplete, progress }: Props) => {
+const UpdateAllApps = ({ state, dispatch, isIncomplete, progress }: Props) => {
   const [appsUpdating, setAppsUpdating] = useState([]);
 
   const { apps, installed, installQueue, uninstallQueue } = state;
@@ -136,6 +135,7 @@ const UpdateAllApps = ({ state, dispatch, plan, isIncomplete, progress }: Props)
     app => (
       <Item
         state={state}
+        installed={state.installed.find(({ name }) => name === app.name)}
         key={`UPDATE_${app.name}`}
         app={app}
         dispatch={dispatch}
@@ -143,11 +143,10 @@ const UpdateAllApps = ({ state, dispatch, plan, isIncomplete, progress }: Props)
         appStoreView={false}
         onlyUpdate={true}
         showActions={false}
-        scheduled={plan.find(a => a.name === app.name)}
-        progress={get(progress, ["appOp", "name"]) === app.name ? progress : null}
+        progress={get(progress, ["appOp", "name"]) === app.name ? progress : undefined}
       />
     ),
-    [state, dispatch, isIncomplete, plan, progress],
+    [state, dispatch, isIncomplete, progress],
   );
 
   const appsToShow = appsUpdating.length > 0 ? appsUpdating : updatableAppList;

--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -6,7 +6,7 @@ import type { TFunction } from "react-i18next";
 import type { DeviceInfo } from "@ledgerhq/live-common/lib/types/manager";
 import type { ListAppsResult, Exec } from "@ledgerhq/live-common/lib/apps/types";
 import type { Device } from "~/renderer/reducers/devices";
-import { getActionPlan, useAppsRunner, isIncompleteState } from "@ledgerhq/live-common/lib/apps";
+import { useAppsRunner, isIncompleteState } from "@ledgerhq/live-common/lib/apps";
 
 import NavigationGuard from "~/renderer/components/NavigationGuard";
 import Quit from "~/renderer/icons/Quit";
@@ -55,7 +55,6 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
   const [appUninstallDep, setAppUninstallDep] = useState(undefined);
   const filteredState = omit(state, "currentProgress");
   const progress = state.currentProgress;
-  const plan = getActionPlan(filteredState) || [];
   const isIncomplete = isIncompleteState(filteredState);
 
   const { installQueue, uninstallQueue, currentError } = filteredState;
@@ -97,14 +96,12 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
         state={filteredState}
         dispatch={dispatch}
         isIncomplete={isIncomplete}
-        plan={plan}
         progress={progress}
       />
       <AppList
         deviceInfo={deviceInfo}
         state={filteredState}
         dispatch={dispatch}
-        plan={plan}
         isIncomplete={isIncomplete}
         progress={progress}
         setAppInstallDep={setAppInstallDep}


### PR DESCRIPTION
Manager V2 cancel buttons on scheduled actions are removed for now since its inconsistent and doesn't work as expected just yet.

+ flow types cleaned up a bit
+ update app label fixed ie: Bitcoin (NEW)

### Type

Bug Fix

### Context

Manager v2

### Parts of the app affected / Test plan

Cancel buttons on scheduled actions (install uninstall update) are now removed.
