### PR TITLE
LL-2194: (ModalContent): fixed horizontal centering for scrollable zone

### DIFF
--- a/src/renderer/components/Modal/ModalContent.js
+++ b/src/renderer/components/Modal/ModalContent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useEffect, useState, useLayoutEffect, useCallback } from "react";
+import React, { useState, useLayoutEffect, useCallback } from "react";
 import styled from "styled-components";
 
 const ContentWrapper = styled.div`
@@ -12,8 +12,8 @@ const ContentWrapper = styled.div`
 `;
 
 const ContentScrollableContainer = styled.div`
-  padding: 20px 20px 40px;
-  ${p => (p.noScroll ? "overflow:visible" : p.theme.overflow.xy)};
+  padding: 20px ${p => (p.noScroll ? 20 : 20 - p.theme.overflow.trackSize)}px 40px 20px;
+  ${p => (p.noScroll ? "overflow:hidden" : p.theme.overflow.xy)};
   position: relative;
   flex: 0 auto;
 `;
@@ -62,8 +62,6 @@ const ModalContent: React$ComponentType<Props> = React.forwardRef(function Modal
       ro.disconnect();
     };
   }, [containerRef, onHeightUpdate]);
-
-  useEffect(() => {}, [isScrollable]); // WAT ?
 
   return (
     <ContentWrapper>


### PR DESCRIPTION
fixed padding on scroll modal content zone

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/74051213-d6dfaa00-49d7-11ea-809e-24a2df0e8f88.png)


### Type

UI Polish

### Context
LL-2194

### Parts of the app affected / Test plan


