### PR TITLE
LL-2184: fix crypto icon padding and sizes

### DIFF
--- a/src/renderer/components/Modal/ModalFooter.js
+++ b/src/renderer/components/Modal/ModalFooter.js
@@ -6,6 +6,7 @@ import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 const ModalFooter: ThemedComponent<{}> = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   border-top: 1px solid ${p => p.theme.colors.palette.divider};
   padding: 20px;
   &:empty {

--- a/src/renderer/components/ParentCryptoCurrencyIcon.js
+++ b/src/renderer/components/ParentCryptoCurrencyIcon.js
@@ -25,6 +25,8 @@ const ParentCryptoCurrencyIconWrapper: ThemedComponent<{
   position: relative;
   line-height: ${p => (p.bigger ? "18px" : "18px")};
   font-size: ${p => (p.bigger ? "12px" : "12px")};
+  max-height: 25px;
+  padding-right: 10px;
   > :nth-child(2) {
     position: absolute;
     bottom: -8px;


### PR DESCRIPTION
fixed padding on crypto icons with tokens

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/74052716-bb29d300-49da-11ea-9b4b-edf24e51a891.png)


### Type

UI Polish

### Context

LL-2184

### Parts of the app affected / Test plan

Modal footer on send erc20 tokens
