### PR TITLE
LL-2193 fixed ledger blue animations

### DIFF
--- a/src/renderer/animations/index.js
+++ b/src/renderer/animations/index.js
@@ -6,7 +6,7 @@ import Lottie from "react-lottie";
 const Animation = ({
   animation,
   width = "100%",
-  height = "auto",
+  height = "100%",
   loop = true,
   autoplay = true,
   rendererSettings = { preserveAspectRatio: "xMidYMin" },

--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -26,7 +26,8 @@ import SupportLinkError from "~/renderer/components/SupportLinkError";
 const AnimationWrapper: ThemedComponent<{ modelId: DeviceModelId }> = styled.div`
   width: 600px;
   max-width: 100%;
-  height: ${p => (p.modelId === "blue" ? "300px" : "200px")};
+  height: ${p => (p.modelId === "blue" ? 300 : 200)}px;
+  padding-bottom: ${p => (p.modelId === "blue" ? 20 : 0)}px;
   align-self: center;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fixed the height of the container of animations for it not to bleed out of the pages

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/74230242-4a2d3880-4cc4-11ea-8552-1a8eaeccf8bf.png)
![localhost_8080_webpack_index html_](https://user-images.githubusercontent.com/11752937/74230246-4bf6fc00-4cc4-11ea-899c-636e83027646.png)
![localhost_8080_webpack_index html__](https://user-images.githubusercontent.com/11752937/74230252-4e595600-4cc4-11ea-9084-a3f37f36334d.png)
![localhost_8080_webpack_index html___](https://user-images.githubusercontent.com/11752937/74230257-4f8a8300-4cc4-11ea-9c73-689a957e0ee0.png)


### Type

UI Polish

### Context

LL-2193

### Parts of the app affected / Test plan

DeviceActions with blue animations
