### PR TITLE
fixed separator being hidden

### DIFF
--- a/src/renderer/components/Bar.js
+++ b/src/renderer/components/Bar.js
@@ -11,6 +11,7 @@ const Bar: ThemedComponent<{
 }> = styled(Box)`
   background: ${p => get(p.theme.colors, p.color)};
   height: ${p => p.size || 1}px;
+  width: 100%;
 `;
 
 export default Bar;


### PR DESCRIPTION
Separators between headers and body of account cards was hidden due to a change in styled system. This PR resolve this issue