### PR TITLE
delay the initial listen devices that happens

### DIFF
--- a/src/renderer/components/ListenDevices.js
+++ b/src/renderer/components/ListenDevices.js
@@ -38,9 +38,11 @@ const ListenDevices = () => {
         },
       );
     }
-    syncDevices();
+
+    const timeoutSyncDevices = setTimeout(syncDevices, 1000);
 
     return () => {
+      clearTimeout(timeoutSyncDevices);
       sub.unsubscribe();
     };
   }, [dispatch]);


### PR DESCRIPTION
at boot of the app we do, inside `events({ store });` a `killInternalProcess();` which means in the previous logic it was ALWAYS crashing the initial listenDevices.

after this PR, we should now have enough delay to not have the internal process booted at the time the kill happens which will be a noop