### PR TITLE
Fix internal process not dying on fatal error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,5 @@ if (cluster.isMaster) {
   require("./main");
 } else {
   // Internal thread (libcore, hardware)
-  try {
-    require("./internal");
-  } catch (err) {
-    console.log(err);
-  }
+  require("./internal");
 }


### PR DESCRIPTION
When `internal` process runs into a fatal error, it should crash and die. But right it doesn't and just zombies out with its associated PID, making it un-obvious from `renderer` that anything went wrong, resulting in an app appearing to run fine while an essential part is down.

This should fix that.

### Type

Bug Fix


### Parts of the app affected

Internal process

### Test plan

- Break internal process
- Make sure the app display a crash screen
