### PR TITLE
LL-2162 Fix: Bad cursor behaviour when mouseovering the breadcrumb

### DIFF
--- a/src/main/window-lifecycle.js
+++ b/src/main/window-lifecycle.js
@@ -51,14 +51,7 @@ export async function createMainWindow({ dimensions, positions }: any) {
     ...defaultWindowOptions,
     x: windowPosition.x,
     y: windowPosition.y,
-    /* eslint-disable indent */
-    ...(process.platform === "darwin"
-      ? {
-          frame: false,
-          titleBarStyle: "hiddenInset",
-        }
-      : {}),
-    /* eslint-enable indent */
+    titleBarStyle: process.platform === "darwin" ? "customButtonsOnHover" : undefined,
     width,
     height,
     minWidth: MIN_WIDTH,


### PR DESCRIPTION
## Known Issue
- According to the [Electron docs](https://www.electronjs.org/docs/api/frameless-window#custombuttonsonhover) customButtonsOnHover shouldn't work with `frame: true` but somehow it works fine here.
- Full screen mode button is disabled when using customButtonsOnHover option