### PR TITLE
Starred from accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "raven": "^2.6.4",
     "raven-js": "^3.27.2",
     "react": "^16.11.0",
-    "react-beautiful-dnd": "^12.2.0",
     "react-dom": "^16.11.0",
     "react-hot-loader": "^4.12.18",
     "react-i18next": "^11.3.3",

--- a/src/renderer/actions/accounts.js
+++ b/src/renderer/actions/accounts.js
@@ -47,4 +47,12 @@ export const updateAccount: UpdateAccount = payload => ({
   },
 });
 
+export const toggleStarAction: UpdateAccount = id => ({
+  type: "DB:UPDATE_ACCOUNT",
+  payload: {
+    updater: (account: Account) => ({ ...account, starred: !account.starred }),
+    accountId: id,
+  },
+});
+
 export const cleanAccountsCache = () => ({ type: "DB:CLEAN_ACCOUNTS_CACHE" });

--- a/src/renderer/actions/general.js
+++ b/src/renderer/actions/general.js
@@ -18,7 +18,6 @@ import {
   getOrderAccounts,
   counterValueCurrencySelector,
   userThemeSelector,
-  starredAccountIdsSelector,
 } from "./../reducers/settings";
 import { accountsSelector, activeAccountsSelector } from "./../reducers/accounts";
 import type { State } from "./../reducers";
@@ -51,7 +50,6 @@ export const calculateCountervalueSelector = (state: State) => {
 export const sortAccountsComparatorSelector: OutputSelector<State, void, *> = createSelector(
   getOrderAccounts,
   calculateCountervalueSelector,
-  starredAccountIdsSelector,
   sortAccountsComparatorFromOrder,
 );
 

--- a/src/renderer/actions/settings.js
+++ b/src/renderer/actions/settings.js
@@ -70,20 +70,5 @@ export const dismissBanner = (bannerKey: string) => ({
   payload: bannerKey,
 });
 
-export const toggleStarAction = (accountId: string) => ({
-  type: "SETTINGS_TOGGLE_STAR",
-  accountId,
-});
-
-export const dragDropStarAction = (payload: { from: string, to: string }) => ({
-  type: "SETTINGS_DRAG_DROP_STAR",
-  payload,
-});
-
-export const replaceStarAccountId = (payload: { oldId: string, newId: string }) => ({
-  type: "SETTINGS_REPLACE_STAR_ID",
-  payload,
-});
-
 export const setPreferredDeviceModel = (preferredDeviceModel: DeviceModelId) =>
   saveSettings({ preferredDeviceModel });

--- a/src/renderer/components/ContextMenu/AccountContextMenu.js
+++ b/src/renderer/components/ContextMenu/AccountContextMenu.js
@@ -9,7 +9,7 @@ import IconSend from "~/renderer/icons/Send";
 import IconStar from "~/renderer/icons/Star";
 import IconAccountSettings from "~/renderer/icons/AccountSettings";
 import ContextMenuItem from "./ContextMenuItem";
-import { toggleStarAction } from "~/renderer/actions/settings";
+import { toggleStarAction } from "~/renderer/actions/accounts";
 import { refreshAccountsOrdering } from "~/renderer/actions/general";
 
 type OwnProps = {

--- a/src/renderer/components/Stars/Item.js
+++ b/src/renderer/components/Stars/Item.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { useCallback } from "react";
 import { useHistory } from "react-router-dom";
-import { Draggable } from "react-beautiful-dnd";
 import styled from "styled-components";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import {
@@ -28,7 +27,7 @@ const ParentCryptoCurrencyIconWrapper: ThemedComponent<{}> = styled.div`
   width: 20px;
 `;
 
-const ItemWrapper = styled.div.attrs(p => ({
+const ItemWrapper: ThemedComponent<{ active: boolean }> = styled.div.attrs(p => ({
   style: {
     backgroundColor: p.active
       ? p.theme.colors.palette.action.hover
@@ -45,15 +44,6 @@ const ItemWrapper = styled.div.attrs(p => ({
   &:hover ${AccountName},&:active ${AccountName} {
     color: ${p => p.theme.colors.palette.text.shade100};
   }
-  ${p =>
-    p.isDragging
-      ? `
-    z-index: 1;
-    border-color: ${p.active ? p.theme.colors.palette.divider : p.theme.colors.sliderGrey};
-    box-shadow: 0 12px 17px 0 rgba(0, 0, 0, 0.1);
-    width: ${p.collapsed ? "200px" : ""} !important;
-        `
-      : ""}
 `;
 
 type Props = {
@@ -77,42 +67,30 @@ const Item = ({ account, index, pathname, collapsed }: Props) => {
   const unit = getAccountUnit(account);
 
   return (
-    <Draggable index={index} draggableId={account.id}>
-      {(provided, snapshot) => (
-        <ItemWrapper
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-          isDragging={snapshot.isDragging}
+    <ItemWrapper collapsed={collapsed} active={active} onClick={onAccountClick}>
+      <Box horizontal ff="Inter|SemiBold" flex={1} flow={3} alignItems="center">
+        <ParentCryptoCurrencyIconWrapper
           collapsed={collapsed}
-          ref={provided.innerRef}
-          active={active && !snapshot.isDragging}
-          onClick={onAccountClick}
+          isToken={account.type === "TokenAccount"}
         >
-          <Box horizontal ff="Inter|SemiBold" flex={1} flow={3} alignItems="center">
-            <ParentCryptoCurrencyIconWrapper
-              collapsed={collapsed}
-              isToken={account.type === "TokenAccount"}
-            >
-              <ParentCryptoCurrencyIcon inactive={!active} currency={getAccountCurrency(account)} />
-            </ParentCryptoCurrencyIconWrapper>
-            <Box vertical flex={1}>
-              <Hide visible={snapshot.isDragging || !collapsed}>
-                <Ellipsis color="palette.text.shade80">{getAccountName(account)}</Ellipsis>
-                <FormattedVal
-                  alwaysShowSign={false}
-                  animateTicker={false}
-                  ellipsis
-                  color="palette.text.shade60"
-                  unit={unit}
-                  showCode
-                  val={account.balance}
-                />
-              </Hide>
-            </Box>
-          </Box>
-        </ItemWrapper>
-      )}
-    </Draggable>
+          <ParentCryptoCurrencyIcon inactive={!active} currency={getAccountCurrency(account)} />
+        </ParentCryptoCurrencyIconWrapper>
+        <Box vertical flex={1}>
+          <Hide visible={!collapsed}>
+            <Ellipsis color="palette.text.shade80">{getAccountName(account)}</Ellipsis>
+            <FormattedVal
+              alwaysShowSign={false}
+              animateTicker={false}
+              ellipsis
+              color="palette.text.shade60"
+              unit={unit}
+              showCode
+              val={account.balance}
+            />
+          </Hide>
+        </Box>
+      </Box>
+    </ItemWrapper>
   );
 };
 

--- a/src/renderer/components/Stars/Star.js
+++ b/src/renderer/components/Stars/Star.js
@@ -4,7 +4,7 @@ import React, { useCallback } from "react";
 import styled, { keyframes } from "styled-components";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
-import { toggleStarAction } from "~/renderer/actions/settings";
+import { toggleStarAction } from "~/renderer/actions/accounts";
 import { isStarredAccountSelector } from "~/renderer/reducers/accounts";
 import { rgba } from "~/renderer/styles/helpers";
 import starAnim from "~/renderer/images/starAnim.png";

--- a/src/renderer/components/Stars/Star.js
+++ b/src/renderer/components/Stars/Star.js
@@ -73,7 +73,7 @@ const StarIcon: ThemedComponent<{
 `;
 
 const mapStateToProps = createStructuredSelector({
-  isAccountStared: isStarredAccountSelector,
+  isAccountStarred: isStarredAccountSelector,
 });
 
 const mapDispatchToProps = {
@@ -88,14 +88,14 @@ type OwnProps = {
 
 type Props = {
   ...OwnProps,
-  isAccountStared: boolean,
+  isAccountStarred: boolean,
   toggleStarAction: Function,
   refreshAccountsOrdering: Function,
 };
 
 const Star = ({
   accountId,
-  isAccountStared,
+  isAccountStarred,
   toggleStarAction,
   yellow,
   refreshAccountsOrdering,
@@ -111,10 +111,12 @@ const Star = ({
   const MaybeButtonWrapper = yellow ? ButtonWrapper : FloatingWrapper;
 
   return (
-    <MaybeButtonWrapper filled={isAccountStared}>
+    <MaybeButtonWrapper filled={isAccountStarred}>
       <StarWrapper onClick={toggleStar}>
-        <Transition in={isAccountStared} timeout={isAccountStared ? startBurstTiming : 0}>
-          {className => <StarIcon yellow={yellow} filled={isAccountStared} className={className} />}
+        <Transition in={isAccountStarred} timeout={isAccountStarred ? startBurstTiming : 0}>
+          {className => (
+            <StarIcon yellow={yellow} filled={isAccountStarred} className={className} />
+          )}
         </Transition>
       </StarWrapper>
     </MaybeButtonWrapper>

--- a/src/renderer/components/Stars/index.js
+++ b/src/renderer/components/Stars/index.js
@@ -1,14 +1,10 @@
 // @flow
-import React, { useCallback } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React from "react";
+import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
-import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import styled from "styled-components";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { getAccountCurrency } from "@ledgerhq/live-common/lib/account";
-import { starredAccountsEnforceHideEmptyTokenSelector } from "~/renderer/reducers/accounts";
-import { dragDropStarAction } from "~/renderer/actions/settings";
-
 import Hide from "~/renderer/components/MainSideBar/Hide";
 import Text from "~/renderer/components/Text";
 import Tooltip from "~/renderer/components/Tooltip";
@@ -17,6 +13,7 @@ import emptyBookmarksDark from "~/renderer/images/dark-empty-bookmarks.png";
 import emptyBookmarksLight from "~/renderer/images/light-empty-bookmarks.png";
 
 import Item from "./Item";
+import { starredAccountsSelector } from "~/renderer/reducers/accounts";
 
 const Container: ThemedComponent<{}> = styled.div`
   display: flex;
@@ -40,54 +37,30 @@ type Props = {
 };
 
 const Stars = ({ pathname, collapsed }: Props) => {
-  const starredAccounts = useSelector(starredAccountsEnforceHideEmptyTokenSelector);
-  const dispatch = useDispatch();
-
-  const onDragEnd = useCallback(
-    ({ source, destination }) => {
-      if (destination) {
-        const from = source.index;
-        const to = destination.index;
-
-        dispatch(
-          dragDropStarAction({ from: starredAccounts[from].id, to: starredAccounts[to].id }),
-        );
-      }
-    },
-    [dispatch, starredAccounts],
-  );
+  const starredAccounts = useSelector(starredAccountsSelector);
 
   return starredAccounts && starredAccounts.length ? (
-    <DragDropContext onDragEnd={onDragEnd}>
-      <Droppable droppableId="starred-account-list" direction="vertical">
-        {(provided, snapshot) => (
-          <Container key={pathname} ref={provided.innerRef} {...provided.droppableProps}>
-            {starredAccounts.map((account, i) => (
-              <Tooltip
-                content={
-                  account.type === "Account" ? account.name : getAccountCurrency(account).name
-                }
-                delay={collapsed ? 0 : 1200}
-                key={account.id}
-                placement={collapsed ? "right" : "top"}
-                boundary={collapsed ? "window" : undefined}
-                enabled={!snapshot.isDraggingOver}
-                flip={!collapsed}
-              >
-                <Item
-                  index={i}
-                  key={account.id}
-                  account={account}
-                  pathname={pathname}
-                  collapsed={collapsed}
-                />
-              </Tooltip>
-            ))}
-            {provided.placeholder}
-          </Container>
-        )}
-      </Droppable>
-    </DragDropContext>
+    <Container key={pathname}>
+      {starredAccounts.map((account, i) => (
+        <Tooltip
+          content={account.type === "Account" ? account.name : getAccountCurrency(account).name}
+          delay={collapsed ? 0 : 1200}
+          key={account.id}
+          placement={collapsed ? "right" : "top"}
+          boundary={collapsed ? "window" : undefined}
+          enabled
+          flip={!collapsed}
+        >
+          <Item
+            index={i}
+            key={account.id}
+            account={account}
+            pathname={pathname}
+            collapsed={collapsed}
+          />
+        </Tooltip>
+      ))}
+    </Container>
   ) : (
     <Hide visible={!collapsed}>
       <Placeholder>

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -28,7 +28,7 @@ import dbMiddleware from "~/renderer/middlewares/db";
 import createStore from "~/renderer/createStore";
 import events from "~/renderer/events";
 import { setAccounts } from "~/renderer/actions/accounts";
-import { fetchSettings } from "~/renderer/actions/settings";
+import { fetchSettings, saveSettings } from "~/renderer/actions/settings";
 import { lock, setOSDarkMode } from "~/renderer/actions/application";
 
 import {
@@ -83,8 +83,15 @@ async function init() {
 
   const isMainWindow = remote.getCurrentWindow().name === "MainWindow";
 
-  const accounts = await getKey("app", "accounts", []);
+  let accounts = await getKey("app", "accounts", []);
   if (accounts) {
+    const { starredAccountIds } = state.settings;
+    if (starredAccountIds && starredAccountIds.length) {
+      await store.dispatch(saveSettings({ starredAccountIds: undefined }));
+      accounts = accounts.map(a =>
+        starredAccountIds.includes(a.id) ? { ...a, starred: true } : a,
+      );
+    }
     await store.dispatch(setAccounts(accounts));
   } else {
     store.dispatch(lock());

--- a/src/renderer/modals/MigrateAccounts/index.js
+++ b/src/renderer/modals/MigrateAccounts/index.js
@@ -21,9 +21,7 @@ import StepCurrency, {
 import { createStructuredSelector } from "reselect";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { accountsSelector, migratableAccountsSelector } from "~/renderer/reducers/accounts";
-import { starredAccountIdsSelector } from "~/renderer/reducers/settings";
 import { replaceAccounts } from "~/renderer/actions/accounts";
-import { replaceStarAccountId } from "~/renderer/actions/settings";
 import { closeModal } from "~/renderer/actions/modals";
 import type { Account, CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 import type { Device } from "~/renderer/reducers/devices";
@@ -32,7 +30,6 @@ type ScanStatus = "idle" | "scanning" | "error" | "finished" | "finished-empty";
 export type StepProps = {
   t: TFunction,
   transitionTo: string => void,
-  starredAccountIds: string[],
   replaceAccounts: (Account[]) => void,
   replaceStarAccountId: ({ oldId: string, newId: string }) => void,
   currencyIds: string[],
@@ -141,21 +138,11 @@ class MigrateAccounts extends PureComponent<*, State> {
     });
 
   render() {
-    const {
-      device,
-      migratableAccounts,
-      currencyIds,
-      accounts,
-      starredAccountIds,
-      replaceAccounts,
-      replaceStarAccountId,
-    } = this.props;
+    const { device, migratableAccounts, currencyIds, accounts, replaceAccounts } = this.props;
     const { stepId, err, scanStatus, currency } = this.state;
 
     const stepperProps = {
-      starredAccountIds,
       replaceAccounts,
-      replaceStarAccountId,
       migratableAccounts,
       currencyIds,
       accounts,
@@ -200,7 +187,6 @@ class MigrateAccounts extends PureComponent<*, State> {
 const mapStateToProps = createStructuredSelector({
   device: getCurrentDevice,
   accounts: accountsSelector,
-  starredAccountIds: starredAccountIdsSelector,
   migratableAccounts: migratableAccountsSelector,
   currencyIds: state =>
     migratableAccountsSelector(state)
@@ -210,7 +196,6 @@ const mapStateToProps = createStructuredSelector({
 
 const mapDispatchToProps = {
   replaceAccounts,
-  replaceStarAccountId,
   closeModal,
 };
 

--- a/src/renderer/modals/MigrateAccounts/steps/StepCurrency.js
+++ b/src/renderer/modals/MigrateAccounts/steps/StepCurrency.js
@@ -63,8 +63,6 @@ class StepCurrency extends PureComponent<StepProps> {
       setScanStatus,
       accounts,
       replaceAccounts,
-      starredAccountIds,
-      replaceStarAccountId,
       addMigratedAccount,
     } = this.props;
 
@@ -90,9 +88,6 @@ class StepCurrency extends PureComponent<StepProps> {
             const maybeMigration = findAccountMigration(a, scannedAccounts);
             if (maybeMigration) {
               totalMigratedAccounts++;
-              if (starredAccountIds.includes(a.id)) {
-                replaceStarAccountId({ oldId: a.id, newId: maybeMigration.id });
-              }
             }
           });
 

--- a/src/renderer/reducers/accounts.js
+++ b/src/renderer/reducers/accounts.js
@@ -14,7 +14,6 @@ import { getEnv } from "@ledgerhq/live-common/lib/env";
 import logger from "./../../logger/logger";
 import accountModel from "./../../helpers/accountModel";
 import { currenciesStatusSelector, currencyDownStatusLocal } from "./currenciesStatus";
-import { starredAccountIdsSelector } from "./settings";
 import type { State } from ".";
 
 export type AccountsState = Account[];
@@ -128,45 +127,15 @@ export const accountSelector: OutputSelector<
   (accounts, accountId) => accounts.find(a => a.id === accountId),
 );
 
-const flattenFilterAndSort = (accounts, ids, flattenOptions) =>
-  flattenAccounts(accounts, flattenOptions)
-    .filter(e => ids.includes(e.id))
-    .sort((a, b) => {
-      const posA = ids.indexOf(a.id);
-      const posB = ids.indexOf(b.id);
-      return posA > posB ? 1 : posA === posB ? 0 : -1;
-    });
-
 export const migratableAccountsSelector = (s: *): Account[] => s.accounts.filter(canBeMigrated);
 
-// TODO: FIX RETURN TYPE
-export const starredAccountsSelector: OutputSelector<State, void, any[]> = createSelector(
-  accountsSelector,
-  starredAccountIdsSelector,
-  flattenFilterAndSort,
-);
-
-// TODO: FIX RETURN TYPE
-export const starredAccountsEnforceHideEmptyTokenSelector: OutputSelector<
-  State,
-  void,
-  any[],
-> = createSelector(
-  accountsSelector,
-  starredAccountIdsSelector,
-  () => getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"), // The result of this func is not used but it allows the input params to be different so that reselect recompute the output
-  (accounts, ids) => flattenFilterAndSort(accounts, ids, { enforceHideEmptySubAccounts: true }),
-);
+export const starredAccountsSelector = (s: *): Account[] => s.accounts.filter(a => a.starred);
 
 export const isStarredAccountSelector: OutputSelector<
   State,
   { accountId: string },
   boolean,
-> = createSelector(
-  starredAccountIdsSelector,
-  (_, { accountId }: { accountId: string }) => accountId,
-  (ids, accountId) => ids.includes(accountId),
-);
+> = createSelector(accountSelector, account => account.starred);
 
 export const accountNeedsMigrationSelector: OutputSelector<
   State,

--- a/src/renderer/reducers/accounts.js
+++ b/src/renderer/reducers/accounts.js
@@ -135,7 +135,7 @@ export const isStarredAccountSelector: OutputSelector<
   State,
   { accountId: string },
   boolean,
-> = createSelector(accountSelector, account => account.starred);
+> = createSelector(accountSelector, account => (account ? account.starred : false));
 
 export const accountNeedsMigrationSelector: OutputSelector<
   State,

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -66,7 +66,6 @@ export type LangAndRegion = { language: string, region: ?string, useSystem: bool
 export type SettingsState = {
   loaded: boolean, // is the settings loaded from db (it not we don't save them)
   hasCompletedOnboarding: boolean,
-  starredAccountIds: string[],
   counterValue: string,
   preferredDeviceModel: DeviceModelId,
   language: ?string,
@@ -104,7 +103,6 @@ const defaultsForCurrency: Currency => CurrencySettings = crypto => {
 
 const INITIAL_STATE: SettingsState = {
   hasCompletedOnboarding: false,
-  starredAccountIds: [],
   counterValue: "USD",
   preferredDeviceModel: "nanoS",
   language: null,
@@ -170,30 +168,6 @@ const handlers: Object = {
   SETTINGS_DISMISS_BANNER: (state: SettingsState, { payload: bannerId }) => ({
     ...state,
     dismissedBanners: [...state.dismissedBanners, bannerId],
-  }),
-  SETTINGS_TOGGLE_STAR: (state: SettingsState, { accountId }) => ({
-    ...state,
-    starredAccountIds: state.starredAccountIds.includes(accountId)
-      ? state.starredAccountIds.filter(e => e !== accountId)
-      : [...state.starredAccountIds, accountId],
-  }),
-  SETTINGS_DRAG_DROP_STAR: (state: SettingsState, { payload: { from, to } }) => {
-    const ids = [...state.starredAccountIds];
-    const fromIndex = ids.indexOf(from);
-    const toIndex = ids.indexOf(to);
-
-    ids.splice(toIndex, 0, ids.splice(fromIndex, 1)[0]);
-
-    return {
-      ...state,
-      starredAccountIds: ids,
-    };
-  },
-  SETTINGS_REPLACE_STAR_ID: (state: SettingsState, { payload: { oldId, newId } }) => ({
-    ...state,
-    starredAccountIds: state.starredAccountIds.map(starredAccountId =>
-      starredAccountId === oldId ? newId : starredAccountId,
-    ),
   }),
   // used to debug performance of redux updates
   DEBUG_TICK: state => ({ ...state }),
@@ -332,7 +306,5 @@ export const exportSettingsSelector: OutputSelector<State, void, *> = createSele
     developerModeEnabled,
   }),
 );
-
-export const starredAccountIdsSelector = (state: State) => state.settings.starredAccountIds;
 
 export default handleActions(handlers, INITIAL_STATE);

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -92,6 +92,7 @@ export type SettingsState = {
   hideEmptyTokenAccounts: boolean,
   sidebarCollapsed: boolean,
   discreetMode: boolean,
+  starredAccountIds?: string[],
 };
 
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10148,7 +10148,7 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-redux@^7.1.1, react-redux@^7.2.0:
+react-redux@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
   integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,14 +852,6 @@
     "@babel/plugin-transform-react-jsx-self" "^7.8.3"
     "@babel/plugin-transform-react-jsx-source" "^7.8.3"
 
-"@babel/runtime-corejs2@^7.6.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.8.3.tgz#b62a61e0c41a90d2d91181fda6de21cecd3a9734"
-  integrity sha512-yxJXBKdIogkfF+wgeJrvU7Afp5ugBi92NzSgNPWWKVoQAlixH3gwMP6yYYr7SV1Dbc0HmNw7WUJkV5ksvtQuHg==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
@@ -3910,13 +3902,6 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
-
-css-box-model@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
-  integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
-  dependencies:
-    tiny-invariant "^1.0.6"
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -8379,7 +8364,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-"memoize-one@>=3.1.1 <6", memoize-one@^5.0.0, memoize-one@^5.1.1:
+"memoize-one@>=3.1.1 <6", memoize-one@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -9997,11 +9982,6 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-raf-schd@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
-  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
-
 raf@^3.1.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -10078,19 +10058,6 @@ rc@^1.2.1, rc@^1.2.7, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-beautiful-dnd@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-12.2.0.tgz#e5f6222f9e7934c6ed4ee09024547f9e353ae423"
-  integrity sha512-s5UrOXNDgeEC+sx65IgbeFlqKKgK3c0UfbrJLWufP34WBheyu5kJ741DtJbsSgPKyNLkqfswpMYr0P8lRj42cA==
-  dependencies:
-    "@babel/runtime-corejs2" "^7.6.3"
-    css-box-model "^1.2.0"
-    memoize-one "^5.1.1"
-    raf-schd "^4.0.2"
-    react-redux "^7.1.1"
-    redux "^4.0.4"
-    use-memo-one "^1.1.1"
 
 react-dom@^16.11.0:
   version "16.12.0"
@@ -10427,7 +10394,7 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.4, redux@^4.0.5:
+redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
@@ -12016,7 +11983,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
@@ -12549,11 +12516,6 @@ usb-detection@^4.5.0:
     eventemitter2 "^5.0.1"
     nan "^2.13.2"
     prebuild-install "^5.1.0"
-
-use-memo-one@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
-  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Completely drop the starred account ids from the settings and use the new field from the accounts model. ~This pr might experience some sorting anomalies since we've adapted the comparator for this new field on https://github.com/LedgerHQ/ledger-live-common/pull/519 but~ (live-common has since been bumped so this is no longer relevant), things that should be tested are: 

- ~On a first launch starred accounts will be lost, this is to be expected since we change the place we are storing them and making a migration makes little sense. Sorry for the inconvenience.~ We've implemented a simple migration logic that will take any existing `starredAccountIds` currently in the settings state and move them to the appropriate account. So please test using an `app.json` that does have starred accounts, it should still have starred accounts when moving to this PR. This can be manually faked by adding a `starredAccountIds` entry into the settings in app.json with an array of account ids. **This field should be eliminated after first launch.**
- We should be able to star accounts
- We should be able to unstar accounts
- We should **no longer** be able to drag and drop items on the sidebar

### Type

Code Quality Improvement, Feature
