### PR TITLE
[Windows] Fix signing certificate not found

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,7 +34,7 @@ win:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}
   icon: build/windows/app.ico
   certificateSubjectName: Ledger SAS
-  certificateSha1: 7dd9acb2ef0402883c65901ebbafd06e5293d391
+  certificateSha1: 7DD9ACB2EF0402883C65901EBBAFD06E5293D391
   signingHashAlgorithms:
     - sha256
   target:


### PR DESCRIPTION
Workaround an `electron-builder` regression: https://github.com/electron-userland/electron-builder/issues/4631