### PR TITLE
LL-2235 Fix broken QRCode for dark themes

### DIFF
--- a/src/renderer/modals/Receive/steps/StepReceiveFunds.js
+++ b/src/renderer/modals/Receive/steps/StepReceiveFunds.js
@@ -33,7 +33,10 @@ const Separator = styled.div`
 `;
 
 const QRCodeWrapper = styled.div`
-  border: 6px solid white;
+  border: 24px solid white;
+  height: 208px;
+  width: 208px;
+  background: white;
 `;
 
 const Receive1ShareAddress = ({
@@ -246,7 +249,7 @@ const StepReceiveFunds = ({
           render={() => (
             <Box alignItems="center">
               <QRCodeWrapper>
-                <QRCode size={211} data={address} />
+                <QRCode size={160} data={address} />
               </QRCodeWrapper>
               <Box mt={6}>
                 <ReadOnlyAddressField address={address} />


### PR DESCRIPTION
There was an extra line in the dark themes under the QRcode that broke the code itself meaning it wasn't scannable on those themes. This fixes that.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2235
### Parts of the app affected / Test plan

Make sure that the last step of the receive flow, the QRcode is scannable when using a dark theme.