### PR TITLE
(ManagerV2) disable add account banner when updates detected

### DIFF
--- a/src/renderer/screens/manager/AppsList/AppsList.js
+++ b/src/renderer/screens/manager/AppsList/AppsList.js
@@ -152,22 +152,20 @@ const AppsList = ({
 
   return (
     <>
-      {update.length <= 0 ? (
-        <InstallSuccessBanner
-          state={state}
-          dispatch={dispatch}
-          isIncomplete={isIncomplete}
-          addAccount={addAccount}
-        />
-      ) : (
-        <UpdateAllApps
-          update={update}
-          state={state}
-          dispatch={dispatch}
-          isIncomplete={isIncomplete}
-          progress={progress}
-        />
-      )}
+      <InstallSuccessBanner
+        state={state}
+        dispatch={dispatch}
+        isIncomplete={isIncomplete}
+        addAccount={addAccount}
+        disabled={update.length >= 1}
+      />
+      <UpdateAllApps
+        update={update}
+        state={state}
+        dispatch={dispatch}
+        isIncomplete={isIncomplete}
+        progress={progress}
+      />
       {isIncomplete ? null : (
         <StickyTabBar>
           <TabBar

--- a/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
+++ b/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
@@ -67,11 +67,12 @@ type Props = {
   dispatch: Action => void,
   isIncomplete: boolean,
   addAccount: (*) => void,
+  disabled: boolean,
 };
 
-const InstallSuccessBanner = ({ state, isIncomplete, dispatch, addAccount }: Props) => {
+const InstallSuccessBanner = ({ state, isIncomplete, dispatch, addAccount, disabled }: Props) => {
   const cardRef = useRef();
-  const [hasBeenShown, setHasBeenShown] = useState(false);
+  const [hasBeenShown, setHasBeenShown] = useState(disabled);
   const { installQueue, uninstallQueue, recentlyInstalledApps, appByName } = state;
 
   const installedSupportedApps = useMemo(() => {


### PR DESCRIPTION
Manager v2
 install banner was showing even in case of update all, now fixed

### Type

Bug Fix
